### PR TITLE
Supporting Hostname Verification based on a configuration

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/logout/LogoutRequestSender.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/logout/LogoutRequestSender.java
@@ -181,9 +181,10 @@ public class LogoutRequestSender {
 
             String hostNameVerificationEnabledProperty =
                     IdentityUtil.getProperty(IdentityConstants.ServerConfig.SLO_HOST_NAME_VERIFICATION_ENABLED);
-            boolean isHostNameVerificationEnabled = StringUtils.isNotBlank(hostNameVerificationEnabledProperty) ?
-                                                    Boolean.parseBoolean(hostNameVerificationEnabledProperty) :
-                                                    true;
+            boolean isHostNameVerificationEnabled = true;
+            if ("false".equalsIgnoreCase(hostNameVerificationEnabledProperty)) {
+                isHostNameVerificationEnabled = false;
+            }
 
             try {
 

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/logout/LogoutRequestSender.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/logout/LogoutRequestSender.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.identity.sso.saml.logout;
 
 import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpEntity;
@@ -26,9 +27,15 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.conn.scheme.Scheme;
-import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicNameValuePair;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
@@ -38,14 +45,13 @@ import org.wso2.carbon.identity.sso.saml.dto.SingleLogoutRequestDTO;
 import org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtil;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
@@ -173,47 +179,45 @@ public class LogoutRequestSender {
                 log.debug("SAMLRequest : " + decodedSAMLRequest);
             }
 
+            String hostNameVerificationEnabledProperty =
+                    IdentityUtil.getProperty(IdentityConstants.ServerConfig.SLO_HOST_NAME_VERIFICATION_ENABLED);
+            boolean isHostNameVerificationEnabled = StringUtils.isNotBlank(hostNameVerificationEnabledProperty) ?
+                                                    Boolean.parseBoolean(hostNameVerificationEnabledProperty) :
+                                                    true;
+
             try {
-                int port = derivePortFromAssertionConsumerURL(logoutReqDTO.getAssertionConsumerURL());
-                UrlEncodedFormEntity entity = new UrlEncodedFormEntity(logoutReqParams, SAMLSSOConstants.ENCODING_FORMAT);
+
+                HttpClient httpClient;
+                if (!isHostNameVerificationEnabled) {
+                    SSLContext sslContext = new SSLContextBuilder().loadTrustMaterial(null, new TrustStrategy() {
+                        public boolean isTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+                            return true;
+                        }
+                    }).build();
+
+                    SSLConnectionSocketFactory sslSocketFactory =
+                            new SSLConnectionSocketFactory(sslContext,
+                                                           SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+                    Registry<ConnectionSocketFactory> socketFactoryRegistry =
+                            RegistryBuilder.<ConnectionSocketFactory>create().register(
+                                    SAMLSSOConstants.COM_PROTOCOL, sslSocketFactory).build();
+                    PoolingHttpClientConnectionManager connectionManager =
+                            new PoolingHttpClientConnectionManager(socketFactoryRegistry);
+
+                    httpClient = HttpClientBuilder.create().setConnectionManager(connectionManager).build();
+                } else {
+                    httpClient = HttpClients.createDefault();
+                }
+
+                UrlEncodedFormEntity entity =
+                        new UrlEncodedFormEntity(logoutReqParams, SAMLSSOConstants.ENCODING_FORMAT);
+
                 HttpPost httpPost = new HttpPost(logoutReqDTO.getAssertionConsumerURL());
                 httpPost.setEntity(entity);
                 httpPost.addHeader(SAMLSSOConstants.COOKIE_PARAM_KEY, SAMLSSOConstants.SESSION_ID_PARAM_KEY + logoutReqDTO.getRpSessionId());
                 if (isSAMLSOAPBindingEnabled) {
                     httpPost.addHeader(SAMLSSOConstants.SOAP_ACTION_PARAM_KEY, SAMLSSOConstants.SOAP_ACTION);
                 }
-                TrustManager easyTrustManager = new X509TrustManager() {
-
-                    @Override
-                    public void checkClientTrusted(
-                            java.security.cert.X509Certificate[] x509Certificates,
-                            String s)
-                            throws java.security.cert.CertificateException {
-                        //overridden method, no method body needed here
-                    }
-
-                    @Override
-                    public void checkServerTrusted(
-                            java.security.cert.X509Certificate[] x509Certificates,
-                            String s)
-                            throws java.security.cert.CertificateException {
-                        //overridden method, no method body needed here
-                    }
-
-                    @Override
-                    public X509Certificate[] getAcceptedIssuers() {
-                        return new X509Certificate[0];
-                    }
-                };
-
-                SSLContext sslContext = SSLContext.getInstance(SAMLSSOConstants.CRYPTO_PROTOCOL);
-                sslContext.init(null, new TrustManager[]{easyTrustManager}, null);
-                SSLSocketFactory sf = new SSLSocketFactory(sslContext);
-                sf.setHostnameVerifier(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
-                Scheme httpsScheme = new Scheme(SAMLSSOConstants.COM_PROTOCOL, sf, port);
-
-                HttpClient httpClient = new DefaultHttpClient();
-                httpClient.getConnectionManager().getSchemeRegistry().register(httpsScheme);
 
                 HttpResponse response = null;
                 boolean isSuccessfullyLogout = false;
@@ -274,14 +278,9 @@ public class LogoutRequestSender {
                 }
 
             } catch (IOException e) {
-                log.error("Error sending logout requests to : " +
-                        logoutReqDTO.getAssertionConsumerURL(), e);
+                log.error("Error sending logout requests to : " + logoutReqDTO.getAssertionConsumerURL(), e);
             } catch (GeneralSecurityException e) {
-                log.error("Error registering the EasySSLProtocolSocketFactory", e);
-            } catch (RuntimeException e) {
-                log.error("Runtime exception occurred.", e);
-            } catch (URISyntaxException e) {
-                log.error("Error deriving port from the assertion consumer url", e);
+                log.error("Error while disabling host name verification.", e);
             }
         }
     }


### PR DESCRIPTION
SAML SLO requests for service providers were initiated without hostname verification which imposes a security risk.
Thus, this fix enables host name verification by default and allows to turn it off by adding following configuration in the repository/conf/identity/identity.xml file under Server\SSOService tag.

&lt;SLOHostNameVerificationEnabled&gt;false&lt;/SLOHostNameVerificationEnabled&gt;

Depends on https://github.com/wso2/carbon-identity-framework/pull/408 and https://github.com/wso2/carbon-identity-framework/pull/407