### PR TITLE
IDENTITY-4819 : SSO flow is not working as expected in chrome

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -548,6 +548,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
             throw IdentityException.error("Unexpected error in sending message out");
         }
 
+        resp.setContentType("text/html; charset=UTF-8");
         if (IdentitySAMLSSOServiceComponent.getSsoRedirectHtml() != null) {
 
             String finalPage = null;


### PR DESCRIPTION
 X-Content-Type-Options header is now enforced. Chrome and IE supports this header and expects 'Content-Type' header always.