### PR TITLE
Removing uncessary import

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -192,7 +192,6 @@
                             org.wso2.carbon.identity.application.common.cache,
                             org.wso2.carbon.identity.application.common.model,
                             org.wso2.carbon.identity.application.common.util,
-                            org.wso2.carbon.identity.base.xsd,
                             org.wso2.carbon.identity.core,
                             org.wso2.carbon.identity.core.dao,
                             org.wso2.carbon.identity.core.persistence,


### PR DESCRIPTION
org.wso2.carbon.identity.base.xsd is un-necessary and causes problems at p2 profile generation of iot pack, after identity component upgrade in app manager.