### PR TITLE
IDENTITY-6206: ACS validation failure when using signed passive saml requests

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -180,6 +180,11 @@ public class SAMLSSOConstants {
         public static final String INVALID_TENANT_DOMAIN = "Service provider tenant domain '%s' is invalid";
         public static final String ERROR_RETRIEVE_SP_CONFIG = "Error occurred while loading Service Provider " +
                                                               "configurations";
+        public static final String SP_NOT_REGISTERED_MESSAGE = "Service provider with issuer '%s' is not registered";
+        public static final String UNKNOWN_DESTINATION_MESSAGE = "Unknown destination URL received";
+        public static final String UNKNOWN_ACS_MESSAGE = "Unknown Assertion Consumer URL received";
+        public static final String INVALID_SIGNATURE_MESSAGE = "Signature validation for the authentication request " +
+                "failed";
 
         private Notification() {
         }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitSSOAuthnRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitSSOAuthnRequestProcessor.java
@@ -49,17 +49,6 @@ public class IdPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor
         try {
             SAMLSSOServiceProviderDO serviceProviderConfigs = getServiceProviderConfig(authnReqDTO);
 
-
-            if (serviceProviderConfigs == null) {
-                String msg =
-                        "A Service Provider with the Issuer '" + authnReqDTO.getIssuer() +
-                                "' is not registered." +
-                                " Service Provider should be registered in advance.";
-                log.warn(msg);
-                return buildErrorResponse(authnReqDTO.getId(),
-                        SAMLSSOConstants.StatusCodes.REQUESTOR_ERROR, msg, null);
-            }
-
             if (!serviceProviderConfigs.isIdPInitSSOEnabled()) {
                 String msg = "IdP initiated SSO not enabled for service provider '" + authnReqDTO.getIssuer() + "'.";
                 log.debug(msg);
@@ -72,9 +61,6 @@ public class IdPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor
                         .parseInt(serviceProviderConfigs
                                 .getAttributeConsumingServiceIndex()));
             }
-
-            // reading the service provider configs
-            populateServiceProviderConfigs(serviceProviderConfigs, authnReqDTO);
 
             String acsUrl = authnReqDTO.getAssertionConsumerURL();
             if (StringUtils.isBlank(acsUrl) || !serviceProviderConfigs.getAssertionConsumerUrlList().contains
@@ -210,41 +196,6 @@ public class IdPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor
         } catch (Exception e) {
             throw IdentityException.error("Error while reading Service Provider configurations", e);
         }
-    }
-
-    /**
-     * Populate the configurations of the service provider
-     *
-     * @param ssoIdpConfigs
-     * @param authnReqDTO
-     * @throws IdentityException
-     */
-    private void populateServiceProviderConfigs(SAMLSSOServiceProviderDO ssoIdpConfigs,
-                                                SAMLSSOAuthnReqDTO authnReqDTO)
-            throws IdentityException {
-
-        if (StringUtils.isBlank(authnReqDTO.getAssertionConsumerURL())) {
-            authnReqDTO.setAssertionConsumerURL(ssoIdpConfigs.getDefaultAssertionConsumerUrl());
-        }
-        authnReqDTO.setLoginPageURL(ssoIdpConfigs.getLoginPageURL());
-        authnReqDTO.setCertAlias(ssoIdpConfigs.getCertAlias());
-        authnReqDTO.setNameIdClaimUri(ssoIdpConfigs.getNameIdClaimUri());
-        authnReqDTO.setNameIDFormat(ssoIdpConfigs.getNameIDFormat());
-        authnReqDTO.setDoSingleLogout(ssoIdpConfigs.isDoSingleLogout());
-        authnReqDTO.setSloResponseURL(ssoIdpConfigs.getSloResponseURL());
-        authnReqDTO.setSloRequestURL(ssoIdpConfigs.getSloRequestURL());
-        authnReqDTO.setDoSignResponse(ssoIdpConfigs.isDoSignResponse());
-        authnReqDTO.setDoSignAssertions(ssoIdpConfigs.isDoSignAssertions());
-        authnReqDTO.setRequestedClaims(ssoIdpConfigs.getRequestedClaims());
-        authnReqDTO.setRequestedAudiences(ssoIdpConfigs.getRequestedAudiences());
-        authnReqDTO.setRequestedRecipients(ssoIdpConfigs.getRequestedRecipients());
-        authnReqDTO.setDoEnableEncryptedAssertion(ssoIdpConfigs.isDoEnableEncryptedAssertion());
-        authnReqDTO.setIdPInitSLOEnabled(ssoIdpConfigs.isIdPInitSLOEnabled());
-        authnReqDTO.setAssertionConsumerURLs(ssoIdpConfigs.getAssertionConsumerUrls());
-        authnReqDTO.setIdpInitSLOReturnToURLs(ssoIdpConfigs.getIdpInitSLOReturnToURLs());
-        authnReqDTO.setSigningAlgorithmUri(ssoIdpConfigs.getSigningAlgorithmUri());
-        authnReqDTO.setDigestAlgorithmUri(ssoIdpConfigs.getDigestAlgorithmUri());
-        authnReqDTO.setAssertionQueryRequestProfileEnabled(ssoIdpConfigs.isAssertionQueryRequestProfileEnabled());
     }
 
     /**

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
@@ -53,19 +53,6 @@ public class SPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor{
         try {
             SAMLSSOServiceProviderDO serviceProviderConfigs = getServiceProviderConfig(authnReqDTO);
 
-            if (serviceProviderConfigs == null) {
-                String msg =
-                        "A Service Provider with the Issuer '" + authnReqDTO.getIssuer() +
-                                "' is not registered." +
-                                " Service Provider should be registered in advance.";
-                log.warn(msg);
-                return buildErrorResponse(authnReqDTO.getId(),
-                        SAMLSSOConstants.StatusCodes.REQUESTOR_ERROR, msg, null);
-            }
-
-            // reading the service provider configs
-            populateServiceProviderConfigs(serviceProviderConfigs, authnReqDTO);
-
             if (authnReqDTO.isDoValidateSignatureInRequests()) {
 
 
@@ -234,44 +221,6 @@ public class SPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor{
         } catch (Exception e) {
             throw IdentityException.error("Error while reading Service Provider configurations", e);
         }
-    }
-
-    /**
-     * Populate the configurations of the service provider
-     *
-     * @param ssoIdpConfigs
-     * @param authnReqDTO
-     * @throws IdentityException
-     */
-    private void populateServiceProviderConfigs(SAMLSSOServiceProviderDO ssoIdpConfigs,
-                                                SAMLSSOAuthnReqDTO authnReqDTO)
-            throws IdentityException {
-
-        // load the ACS url, if it is not defined in the request. If it is sent in request,  if must owner it.
-        String acsUrl = authnReqDTO.getAssertionConsumerURL();
-        if (StringUtils.isBlank(acsUrl)) {
-            authnReqDTO.setAssertionConsumerURL(ssoIdpConfigs.getDefaultAssertionConsumerUrl());
-        }
-        authnReqDTO.setLoginPageURL(ssoIdpConfigs.getLoginPageURL());
-        authnReqDTO.setCertAlias(ssoIdpConfigs.getCertAlias());
-        authnReqDTO.setNameIdClaimUri(ssoIdpConfigs.getNameIdClaimUri());
-        authnReqDTO.setNameIDFormat(ssoIdpConfigs.getNameIDFormat());
-        authnReqDTO.setDoSingleLogout(ssoIdpConfigs.isDoSingleLogout());
-        authnReqDTO.setSloResponseURL(ssoIdpConfigs.getSloResponseURL());
-        authnReqDTO.setSloRequestURL(ssoIdpConfigs.getSloRequestURL());
-        authnReqDTO.setDoSignResponse(ssoIdpConfigs.isDoSignResponse());
-        authnReqDTO.setDoSignAssertions(ssoIdpConfigs.isDoSignAssertions());
-        authnReqDTO.setRequestedClaims(ssoIdpConfigs.getRequestedClaims());
-        authnReqDTO.setRequestedAudiences(ssoIdpConfigs.getRequestedAudiences());
-        authnReqDTO.setRequestedRecipients(ssoIdpConfigs.getRequestedRecipients());
-        authnReqDTO.setDoEnableEncryptedAssertion(ssoIdpConfigs.isDoEnableEncryptedAssertion());
-        authnReqDTO.setDoValidateSignatureInRequests(ssoIdpConfigs.isDoValidateSignatureInRequests());
-        authnReqDTO.setIdPInitSLOEnabled(ssoIdpConfigs.isIdPInitSLOEnabled());
-        authnReqDTO.setAssertionConsumerURLs(ssoIdpConfigs.getAssertionConsumerUrls());
-        authnReqDTO.setIdpInitSLOReturnToURLs(ssoIdpConfigs.getIdpInitSLOReturnToURLs());
-        authnReqDTO.setSigningAlgorithmUri(ssoIdpConfigs.getSigningAlgorithmUri());
-        authnReqDTO.setDigestAlgorithmUri(ssoIdpConfigs.getDigestAlgorithmUri());
-        authnReqDTO.setAssertionQueryRequestProfileEnabled(ssoIdpConfigs.isAssertionQueryRequestProfileEnabled());
     }
 
     /**

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/validators/SPInitSSOAuthnRequestValidator.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/validators/SPInitSSOAuthnRequestValidator.java
@@ -119,32 +119,6 @@ public class SPInitSSOAuthnRequestValidator implements SSOAuthnRequestValidator{
                 return validationResponse;
             }
 
-            //TODO : REMOVE THIS UNNECESSARY CHECK
-            // set the custom login page URL and ACS URL if available
-            SSOServiceProviderConfigManager spConfigManager = SSOServiceProviderConfigManager.getInstance();
-            SAMLSSOServiceProviderDO spDO = spConfigManager.getServiceProvider(issuer.getValue());
-            String spAcsUrl = null;
-            if (spDO != null) {
-                validationResponse.setLoginPageURL(spDO.getLoginPageURL());
-                spAcsUrl = spDO.getAssertionConsumerUrl();
-            }
-            // Check for a Spoofing attack
-            String acsUrl = authnReq.getAssertionConsumerServiceURL();
-            if ( StringUtils.isNotBlank(spAcsUrl) && StringUtils.isNotBlank(acsUrl) && !acsUrl.equals(spAcsUrl)) {
-                log.error("Invalid ACS URL value " + acsUrl + " in the AuthnRequest message from " +
-                        spDO.getIssuer() + "\n" +
-                        "Possibly an attempt for a spoofing attack from Provider " +
-                        authnReq.getIssuer().getValue());
-
-                String errorResp = SAMLSSOUtil.buildErrorResponse(
-                        SAMLSSOConstants.StatusCodes.REQUESTOR_ERROR,
-                        "Invalid Assertion Consumer Service URL in the Authentication Request.",
-                        acsUrl);
-                validationResponse.setResponse(errorResp);
-                validationResponse.setValid(false);
-                return validationResponse;
-            }
-
             //TODO : Validate the NameID Format
             if (subject != null && subject.getNameID() != null) {
                 validationResponse.setSubject(subject.getNameID().getValue());


### PR DESCRIPTION
SAML request ACS, destination and signatures are validated after the authentication response is received from the framework and handled by the authentication processors separately for SP initiated and IdP initiated login.
When the IdP failed to authenticate the user in passive mode, SAML request was not properly validated for signing and ACS, destination URLs were not properly validated due to above model.
With this fix, validation for the existence of the SP for the provided issuer were brought to the servlet from the processors. Then ACS and destination URLs and request signing is validated for the passive request, when user authentication has failed before responding.