### PR TITLE
IDENTITY:3355 remove exception trace from warning log

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -881,7 +881,11 @@ public class SAMLSSOUtil {
             return false;
         } catch (IdentitySAML2SSOException e) {
             log.warn("Signature validation failed for the SAML Message : Failed to construct the X509CredentialImpl for the alias " +
-                    alias, e);
+                    alias);
+            if (log.isDebugEnabled()) {
+                log.debug("Signature validation failed for the SAML Message : Failed to construct the X509CredentialImpl for the alias " +
+                        alias, e);
+            }
             return false;
         } catch (ClassNotFoundException e) {
             throw IdentityException.error("Class not found: "


### PR DESCRIPTION
[IDENTITY:3355](https://wso2.org/jira/browse/IDENTITY-3355) Better if only warning is shown for signature verification failures (not the whole exception)