### PR TITLE
IDENTITY-6391: Add 'wso2carbon' as the default certificate alias.

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml.ui/src/main/java/org/wso2/carbon/identity/sso/saml/ui/SAMLSSOUIConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml.ui/src/main/java/org/wso2/carbon/identity/sso/saml/ui/SAMLSSOUIConstants.java
@@ -55,6 +55,7 @@ public class SAMLSSOUIConstants {
     public static final String SAML_SSO_KEY_ENCRYPTION_ALGORITHM = "keyEncryptionAlgorithm";
     public static final String ENABLE_ASSERTION_QUERY_REQUEST_PROFILE = "enableAssertionQueryRequestProfile";
     public static final String SUPPORTED_ASSERTION_QUERY_REQUEST_TYPES = "supportedAssertionQueryRequestTypes";
+    public static final String DEFAULT_CERTIFICATE_ALIAS = "wso2carbon";
 
     private SAMLSSOUIConstants() {
     }

--- a/components/org.wso2.carbon.identity.sso.saml.ui/src/main/resources/web/sso-saml/add_service_provider.jsp
+++ b/components/org.wso2.carbon.identity.sso.saml.ui/src/main/resources/web/sso-saml/add_service_provider.jsp
@@ -960,17 +960,25 @@
                                         <select id="alias" name="alias">
                                             <%
                                                 if (aliasSet != null) {
+                                                    boolean isDefaultAliasSet = false;
                                                     for (String alias : aliasSet) {
                                                         if (alias != null && alias.equals(provider.getCertAlias())) {
+                                                            isDefaultAliasSet = true;
                                             %>
-                                            <option selected="selected"
-                                                    value="<%=Encode.forHtmlAttribute(alias)%>"><%=Encode.forHtmlContent(alias)%>
-                                            </option>
+                                                            <option selected="selected"
+                                                                 value="<%=Encode.forHtmlAttribute(alias)%>"><%=Encode.forHtmlContent(alias)%>
+                                                            </option>
                                             <%
-                                            } else {
+                                                        } else if (alias != null && !isDefaultAliasSet && alias.equals(SAMLSSOUIConstants.DEFAULT_CERTIFICATE_ALIAS)) {
                                             %>
-                                            <option value="<%=Encode.forHtmlAttribute(alias)%>"><%=Encode.forHtmlContent(alias)%>
-                                            </option>
+                                                            <option selected="selected"
+                                                                value="<%=Encode.forHtmlAttribute(alias)%>"><%=Encode.forHtmlContent(alias)%>
+                                                            </option>
+                                            <%
+                                                        } else {
+                                            %>
+                                                            <option value="<%=Encode.forHtmlAttribute(alias)%>"><%=Encode.forHtmlContent(alias)%>
+                                                            </option>
                                             <%
                                                         }
                                                     }
@@ -987,17 +995,25 @@
                                         <select id="alias" name="alias">
                                             <%
                                                 if (aliasSet != null) {
+                                                    boolean isDefaultAliasSet = false;
                                                     for (String alias : aliasSet) {
                                                         if (alias != null && alias.equals(samlSsoServuceProviderConfigBean.getCertificateAlias())) {
+                                                            isDefaultAliasSet = true;
                                             %>
-                                            <option selected="selected"
-                                                    value="<%=Encode.forHtmlAttribute(alias)%>"><%=Encode.forHtmlContent(alias)%>
-                                            </option>
+                                                            <option selected="selected"
+                                                                value="<%=Encode.forHtmlAttribute(alias)%>"><%=Encode.forHtmlContent(alias)%>
+                                                            </option>
                                             <%
-                                            } else {
+                                                        } else if (alias != null && !isDefaultAliasSet && alias.equals(SAMLSSOUIConstants.DEFAULT_CERTIFICATE_ALIAS)) {
                                             %>
-                                            <option value="<%=Encode.forHtmlAttribute(alias)%>"><%=Encode.forHtmlContent(alias)%>
-                                            </option>
+                                                            <option selected="selected"
+                                                                value="<%=Encode.forHtmlAttribute(alias)%>"><%=Encode.forHtmlContent(alias)%>
+                                                            </option>
+                                            <%
+                                                        } else {
+                                            %>
+                                                            <option value="<%=Encode.forHtmlAttribute(alias)%>"><%=Encode.forHtmlContent(alias)%>
+                                                            </option>
                                             <%
                                                         }
                                                     }


### PR DESCRIPTION
Added mechanism to point the 'wso2carbon' certificate as the default certificate in the SAML SP configuration page.