### PR TITLE
IDENTITY-4995: Add facility to disable certificate alias list.

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml.ui/src/main/resources/web/sso-saml/add_service_provider.jsp
+++ b/components/org.wso2.carbon.identity.sso.saml.ui/src/main/resources/web/sso-saml/add_service_provider.jsp
@@ -1866,6 +1866,27 @@
                 }
 
             </script>
+            <script type="text/javascript">
+                
+                // Update the certificate alias list down accessibility according to the enable signature validation
+                // check box.
+                $(document).ready(function () {
+                    var enableSigValidation = $("#enableSigValidation");
+                    updateCertificateAliasListAccess(enableSigValidation.is(':checked'));
+                    enableSigValidation.change(function () {
+                        updateCertificateAliasListAccess(this.checked);
+                    })
+                });
+                
+                function updateCertificateAliasListAccess(enable) {
+                    if (enable) {
+                        $("#alias").prop('disabled', false);
+                    } else {
+                        $("#alias").prop('disabled', 'disabled');
+                    }
+                }
+    
+            </script>
         </div>
 
     </div>


### PR DESCRIPTION
Certificate alias list down will be disabled now if signature verification box is not ticked in SAML service provider configuration.
https://wso2.org/jira/browse/IDENTITY-4995