### PR TITLE
product-is-2264 : Store SAML Metadata embedded certificate

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml.stub/src/main/resources/IdentitySAMLSSOConfigService.wsdl
+++ b/components/org.wso2.carbon.identity.sso.saml.stub/src/main/resources/IdentitySAMLSSOConfigService.wsdl
@@ -203,6 +203,7 @@
                     <xs:element minOccurs="0" name="assertionQueryRequestProfileEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="attributeConsumingServiceIndex" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="certAlias" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="certificateContent" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="defaultAssertionConsumerUrl" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="digestAlgorithmURI" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="doEnableEncryptedAssertion" type="xs:boolean"/>

--- a/components/org.wso2.carbon.identity.sso.saml.ui/src/main/java/org/wso2/carbon/identity/sso/saml/ui/SAMLSSOUIConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml.ui/src/main/java/org/wso2/carbon/identity/sso/saml/ui/SAMLSSOUIConstants.java
@@ -57,6 +57,8 @@ public class SAMLSSOUIConstants {
     public static final String SUPPORTED_ASSERTION_QUERY_REQUEST_TYPES = "supportedAssertionQueryRequestTypes";
     public static final String DEFAULT_CERTIFICATE_ALIAS = "wso2carbon";
 
+    public static final String SESSION_ATTRIBUTE_NAME_APPLICATION_CERTIFICATE = "applicationCertificate";
+
     private SAMLSSOUIConstants() {
     }
 }

--- a/components/org.wso2.carbon.identity.sso.saml.ui/src/main/java/org/wso2/carbon/identity/sso/saml/ui/client/SamlSPMetadataUploadExecutor.java
+++ b/components/org.wso2.carbon.identity.sso.saml.ui/src/main/java/org/wso2/carbon/identity/sso/saml/ui/client/SamlSPMetadataUploadExecutor.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.sso.saml.ui.client;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.identity.sso.saml.stub.types.SAMLSSOServiceProviderDTO;
+import org.wso2.carbon.identity.sso.saml.ui.SAMLSSOUIConstants;
 import org.wso2.carbon.ui.CarbonUIMessage;
 import org.wso2.carbon.ui.transports.fileupload.AbstractFileUploadExecutor;
 import org.wso2.carbon.utils.FileItemData;
@@ -96,6 +97,13 @@ public class SamlSPMetadataUploadExecutor extends AbstractFileUploadExecutor {
                 if (serviceProviderDTO.getAttributeConsumingServiceIndex() != null) {
                     attributeConsumingServiceIndex = serviceProviderDTO.getAttributeConsumingServiceIndex();
                 }
+
+                // Store the certificate contained inside the metadata file, in the session.
+                // This will be used by service provider update operation to know the certificate came inside SAML
+                // metadata file.
+                httpServletRequest.getSession().setAttribute(SAMLSSOUIConstants
+                                .SESSION_ATTRIBUTE_NAME_APPLICATION_CERTIFICATE,
+                        serviceProviderDTO.getCertificateContent());
 
                 CarbonUIMessage.sendCarbonUIMessage(msg, CarbonUIMessage.INFO, httpServletRequest,
                         httpServletResponse, getContextRoot(httpServletRequest)

--- a/components/org.wso2.carbon.identity.sso.saml.ui/src/main/resources/web/sso-saml/add_service_provider.jsp
+++ b/components/org.wso2.carbon.identity.sso.saml.ui/src/main/resources/web/sso-saml/add_service_provider.jsp
@@ -1849,16 +1849,7 @@
                         CARBON.showWarningDialog("<fmt:message key='sp.metadata.valid.file'/>");
                         return;
                     }
-
-                    <% if (MultitenantConstants.SUPER_TENANT_ID ==
-                    CarbonContext.getThreadLocalCarbonContext().getTenantId()) { %>
-                    CARBON.showConfirmationDialog("<fmt:message key='sp.saml.metadata.certificate.warn'/>",
-                            function () {
-                                document.uploadServiceProvider.submit();
-                            });
-                    <% } else { %>
                     document.uploadServiceProvider.submit();
-                    <% } %>
                 }
 
                 function doCancel() {

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -81,6 +81,8 @@ public class SAMLSSOConstants {
 
     public static final String AUTHN_CONTEXT_CLASS_REF = "AuthnContextClassRef";
     public static final String SAML_SSO_ENCRYPTOR_CONFIG_PATH = "SSOService.SAMLSSOEncrypter";
+    public static final String SAML2_HTTP_REDIRECT_SIGNATURE_VALIDATOR_CLASS_NAME = "SSOService.SAML2HTTPRedirectSignatureValidator";
+    public static final String SAMLSSO_SIGNER_CLASS_NAME = "SSOService.SAMLSSOSigner";
 
     private SAMLSSOConstants() {
     }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 
 import java.security.KeyStore;
+import java.security.cert.CertificateException;
 
 /**
  * This class is used for managing SAML SSO providers. Adding, retrieving and removing service
@@ -265,6 +266,18 @@ public class SAMLSSOConfigAdmin {
         serviceProviderDTO.setAssertionConsumerUrls(serviceProviderDO.getAssertionConsumerUrls());
         serviceProviderDTO.setDefaultAssertionConsumerUrl(serviceProviderDO.getDefaultAssertionConsumerUrl());
         serviceProviderDTO.setCertAlias(serviceProviderDO.getCertAlias());
+
+        try {
+
+            if (serviceProviderDO.getX509Certificate() != null) {
+                serviceProviderDTO.setCertificateContent(IdentityUtil.convertCertificateToPEM(
+                        serviceProviderDO.getX509Certificate()));
+            }
+        } catch (CertificateException e) {
+            throw new IdentityException("An error occurred while converting the application certificate to " +
+                    "PEM content.", e);
+        }
+
         serviceProviderDTO.setDoSingleLogout(serviceProviderDO.isDoSingleLogout());
         serviceProviderDTO.setLoginPageURL(serviceProviderDO.getLoginPageURL());
         serviceProviderDTO.setSloRequestURL(serviceProviderDO.getSloRequestURL());

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
@@ -32,6 +32,7 @@ public class SAMLSSOServiceProviderDTO implements Serializable {
     private String defaultAssertionConsumerUrl;
     private String assertionConsumerUrl;
     private String certAlias;
+    private String certificateContent;
     private String sloResponseURL;
     private String sloRequestURL;
     private String loginPageURL;
@@ -379,5 +380,15 @@ public class SAMLSSOServiceProviderDTO implements Serializable {
         } else {
             this.idpInitSLOReturnToURLs = null;
         }
+    }
+
+    public void setCertificateContent(String certificateContent) {
+
+        this.certificateContent = certificateContent;
+    }
+
+    public String getCertificateContent() {
+
+        return certificateContent;
     }
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
@@ -441,7 +441,7 @@ public class SPInitLogoutRequestProcessor implements SPInitSSOLogoutRequestProce
             validationResult.setValidationStatus(false);
         }
 
-        if (!SAMLSSOUtil.validateLogoutRequestSignature(logoutRequest, logoutReqIssuer.getCertAlias(), subject,
+        if (!SAMLSSOUtil.validateLogoutRequestSignature(logoutRequest, logoutReqIssuer.getX509Certificate(),
                 queryString)) {
             String message = "Signature validation for Logout Request failed";
             log.error(message);

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
@@ -81,7 +81,8 @@ public class SPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor{
                 }
 
                 // validate the signature
-                boolean isSignatureValid = SAMLSSOUtil.validateAuthnRequestSignature(authnReqDTO);
+                boolean isSignatureValid = SAMLSSOUtil.validateAuthnRequestSignature(authnReqDTO,
+                        serviceProviderConfigs.getX509Certificate());
 
                 if (!isSignatureValid) {
                     String msg = "Signature validation for Authentication Request failed.";

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -802,7 +802,8 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                     }
 
                     // Validate signature.
-                    if (!SAMLSSOUtil.validateAuthnRequestSignature(authnReqDTO)) {
+                    if (!SAMLSSOUtil.validateAuthnRequestSignature(authnReqDTO,
+                            serviceProviderConfigs.getX509Certificate())) {
                         String msg = "Signature validation of the authentication request failed for issuer : " +
                                 issuer + " in tenant domain : " + tenantDomain;
                         log.warn(msg);

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/validators/SAML2HTTPRedirectSignatureValidator.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/validators/SAML2HTTPRedirectSignatureValidator.java
@@ -20,10 +20,37 @@ package org.wso2.carbon.identity.sso.saml.validators;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.sso.saml.exception.IdentitySAML2SSOException;
 
+import java.security.cert.X509Certificate;
+
 public interface SAML2HTTPRedirectSignatureValidator {
 
     public void init() throws IdentityException;
 
+    /**
+     *
+     * @deprecated Use {@link #validateSignature(String, String, X509Certificate)}  instead.
+     *
+     * @param queryString
+     * @param issuer
+     * @param alias
+     * @param domainName
+     * @return
+     * @throws org.opensaml.xml.security.SecurityException
+     * @throws IdentitySAML2SSOException
+     */
+    @Deprecated
     public boolean validateSignature(String queryString, String issuer, String alias,
                                      String domainName) throws org.opensaml.xml.security.SecurityException, IdentitySAML2SSOException;
+
+    /**
+     * Validates the signature of the given SAML request against the given signature.
+     *
+     * @param queryString SAML request (passed an an HTTP query parameter)
+     * @param issuer      Issuer of the SAML request
+     * @param certificate Certificate for validating the signature
+     * @return true if the signature is valid, false otherwise.
+     * @throws org.opensaml.xml.security.SecurityException if something goes wrong during signature validation.
+     */
+    boolean validateSignature(String queryString, String issuer, X509Certificate certificate)
+            throws org.opensaml.xml.security.SecurityException;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,7 @@
     <properties>
 
         <carbon.kernel.version>4.4.7</carbon.kernel.version>
-        <carbon.identity.framework.version>5.11.13</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.11.16</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Currently, the certificate is ignored and the user is informed to import the certificate to the Keystore beforehand.

This commit also adds SAML counterpart of DB based application certificate storing feature.

This PR fixes the issue #[2264](https://github.com/wso2/product-is/issues/2264)