### PR TITLE
Fix #4776:Failed to store SAML assertion when Assertion Query Request profile enabled

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/ExtendedDefaultAssertionBuilder.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/ExtendedDefaultAssertionBuilder.java
@@ -23,11 +23,12 @@ import org.apache.commons.logging.LogFactory;
 import org.joda.time.DateTime;
 import org.opensaml.saml2.core.Assertion;
 import org.wso2.carbon.identity.base.IdentityException;
-import org.wso2.carbon.identity.core.persistence.JDBCPersistenceManager;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOAuthnReqDTO;
+import org.wso2.carbon.identity.sso.saml.util.DBUtil;
 import org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtil;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -44,13 +45,10 @@ public class ExtendedDefaultAssertionBuilder extends DefaultSAMLAssertionBuilder
      * Standard login
      */
     private final static Log log = LogFactory.getLog(ExtendedDefaultAssertionBuilder.class);
-    private final static String ASSERTION_STORE_SQL = "INSERT INTO IDN_SAML2_ASSERTION_STORE(SAML2_ID," +
-            "SAML2_ISSUER,SAML2_SUBJECT, SAML2_SESSION_INDEX, SAML2_AUTHN_CONTEXT_CLASS_REF ,SAML2_ASSERTION) VALUES (?,?,?,?,?,?)";
 
     /**
      * This method is used to initialize
      *
-     * @throws IdentityException If error occurred
      */
     @Override
     public void init() throws IdentityException {
@@ -82,34 +80,38 @@ public class ExtendedDefaultAssertionBuilder extends DefaultSAMLAssertionBuilder
 
     private void persistAssertion(SAMLSSOAuthnReqDTO samlssoAuthnReqDTO, Assertion assertion) throws IdentityException {
 
-        Connection connection = null;
-        PreparedStatement preparedStatement = null;
-        try {
-            connection = JDBCPersistenceManager.getInstance().getDBConnection();
-            preparedStatement = connection.prepareStatement(ASSERTION_STORE_SQL);
+        String assertionPersistenceQuery = "INSERT INTO IDN_SAML2_ASSERTION_STORE(SAML2_ID," +
+                "SAML2_ISSUER,SAML2_SUBJECT, SAML2_SESSION_INDEX, SAML2_AUTHN_CONTEXT_CLASS_REF, SAML2_ASSERTION)"
+                + " VALUES (?,?,?,?,?,?)";
+        if (DBUtil.isAssertionDTOPersistenceSupported()) {
+            assertionPersistenceQuery = "INSERT INTO IDN_SAML2_ASSERTION_STORE(SAML2_ID," +
+                    "SAML2_ISSUER,SAML2_SUBJECT, SAML2_SESSION_INDEX, SAML2_AUTHN_CONTEXT_CLASS_REF, ASSERTION)"
+                    + " VALUES (?,?,?,?,?,?)";
+        }
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(assertionPersistenceQuery)) {
+
             preparedStatement.setString(1, assertion.getID());
             preparedStatement.setString(2, assertion.getIssuer().getValue());
             preparedStatement.setString(3, samlssoAuthnReqDTO.getUser().getAuthenticatedSubjectIdentifier());
             preparedStatement.setString(4, assertion.getAuthnStatements().get(0).getSessionIndex());
             preparedStatement.setString(5, assertion.getAuthnStatements().get(0).getAuthnContext().
                     getAuthnContextClassRef().getAuthnContextClassRef());
+
             String assertionString = SAMLSSOUtil.marshall(assertion);
-            preparedStatement.setString(6, assertionString);
+            if (DBUtil.isAssertionDTOPersistenceSupported()) {
+                DBUtil.setBlobObject(preparedStatement, assertionString, 6);
+            } else {
+                preparedStatement.setString(6, assertionString);
+            }
+
             preparedStatement.executeUpdate();
             connection.commit();
         } catch (SQLException e) {
             log.error("Error while writing data", e);
-        } finally {
-            try {
-                if (preparedStatement != null) {
-                    IdentityDatabaseUtil.closeStatement(preparedStatement);
-                }
-                if (connection != null) {
-                    IdentityDatabaseUtil.closeConnection(connection);
-                }
-            } catch (Exception ex) {
-                log.error("Error while closing the stream", ex);
-            }
+        } catch (IOException e) {
+            log.error("Could not set Assertion as a Blob.", e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/DBUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/DBUtil.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.sso.saml.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class DBUtil {
+
+    private static Log log = LogFactory.getLog(SAMLSSOUtil.class);
+
+    private static final String SAML2_ASSERTION_STORE = "IDN_SAML2_ASSERTION_STORE";
+    private static final String ASSERTION = "ASSERTION";
+
+    private static boolean isAssertionDTOPersistenceSupported = false;
+    private static boolean isAssertionDTOPersistenceStatusChecked = false;
+
+    private DBUtil() {}
+
+    /**
+     * Return if IDN_SAML2_ASSERTION_STORE table has ASSERTION column.
+     *
+     * @return Existence of ASSERTION column in IDN_SAML2_ASSERTION_STORE
+     */
+    public static boolean isAssertionDTOPersistenceSupported() {
+
+        if (!isAssertionDTOPersistenceStatusChecked) {
+            try (Connection connection = IdentityDatabaseUtil.getDBConnection()) {
+
+                DatabaseMetaData metaData = connection.getMetaData();
+                ResultSet rs = metaData.getColumns(null, null, SAML2_ASSERTION_STORE, ASSERTION);
+                if (rs.next()) {
+                    isAssertionDTOPersistenceSupported = true;
+                }
+            } catch (SQLException e) {
+                log.error("Error in fetching metadata from IDN_SAML2_ASSERTION_STORE database", e);
+            }
+            isAssertionDTOPersistenceStatusChecked = true;
+        }
+        return isAssertionDTOPersistenceSupported;
+    }
+
+    /**
+     * Retun java object from input stream. Used to retrieve blob objects from database.
+     *
+     * @param is Input stream.
+     * @return Java object constructed from the input stream.
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    public static Object getBlobObject(InputStream is) throws IOException, ClassNotFoundException {
+
+        if (is != null) {
+            ObjectInput ois = null;
+            try {
+                ois = new ObjectInputStream(is);
+                return ois.readObject();
+            } finally {
+                if (ois != null) {
+                    ois.close();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Serialize an object and set into a prepared statement as a blob.
+     *
+     * @param prepStmt Prepared statement.
+     * @param value    Object to be saved.
+     * @param index    Index of the prepared statement.
+     * @throws SQLException
+     * @throws IOException
+     */
+    public static void setBlobObject(PreparedStatement prepStmt, Object value, int index) throws SQLException, IOException {
+        if (value != null) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(value);
+            oos.flush();
+            oos.close();
+            InputStream inputStream = new ByteArrayInputStream(baos.toByteArray());
+            prepStmt.setBinaryStream(index, inputStream, inputStream.available());
+        } else {
+            prepStmt.setBinaryStream(index, null, 0);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -21,7 +21,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.xerces.impl.Constants;
 import org.joda.time.DateTime;
 import org.opensaml.Configuration;
 import org.opensaml.DefaultBootstrap;
@@ -114,6 +113,8 @@ import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -143,26 +144,20 @@ import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 public class SAMLSSOUtil {
 
-    private static final char[] charMapping = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
-            'k', 'l', 'm', 'n', 'o', 'p'};
+    private static Log log = LogFactory.getLog(SAMLSSOUtil.class);
     private static final Set<Character> UNRESERVED_CHARACTERS = new HashSet<>();
     private static final ThreadLocal<Boolean> isSaaSApplication = new ThreadLocal<>();
     private static final ThreadLocal<String> userTenantDomainThreadLocal = new ThreadLocal<>();
     private static final String DefaultAssertionBuilder = "org.wso2.carbon.identity.sso.saml.builders.assertion.DefaultSAMLAssertionBuilder";
-    private static final String SECURITY_MANAGER_PROPERTY = Constants.XERCES_PROPERTY_PREFIX +
-            Constants.SECURITY_MANAGER_PROPERTY;
-    private static final int ENTITY_EXPANSION_LIMIT = 0;
 
     static {
         for (char c = 'a'; c <= 'z'; c++)
             UNRESERVED_CHARACTERS.add(Character.valueOf(c));
 
-        for (char c = 'A'; c <= 'A'; c++)
+        for (char c = 'A'; c <= 'Z'; c++)
             UNRESERVED_CHARACTERS.add(Character.valueOf(c));
 
         for (char c = '0'; c <= '9'; c++)
@@ -174,7 +169,6 @@ public class SAMLSSOUtil {
         UNRESERVED_CHARACTERS.add(Character.valueOf('~'));
     }
 
-    private static Log log = LogFactory.getLog(SAMLSSOUtil.class);
     private static RegistryService registryService;
     private static TenantRegistryLoader tenantRegistryLoader;
     private static BundleContext bundleContext;
@@ -193,7 +187,6 @@ public class SAMLSSOUtil {
     private static String iDPInitSSOAuthnRequestValidatorClassName = null;
     private static ThreadLocal tenantDomainInThreadLocal = new ThreadLocal();
     private static String idPInitLogoutRequestProcessorClassName = null;
-    private static String idPInitSSOAuthnRequestProcessorClassName = null;
     private static String sPInitSSOAuthnRequestProcessorClassName = null;
     private static String sPInitLogoutRequestProcessorClassName = null;
     private static ApplicationManagementService applicationMgtService;
@@ -203,11 +196,6 @@ public class SAMLSSOUtil {
     }
 
     public static boolean isSaaSApplication() {
-
-        if (isSaaSApplication == null) {
-            // this is the default behavior.
-            return true;
-        }
 
         Boolean value = isSaaSApplication.get();
 
@@ -227,11 +215,6 @@ public class SAMLSSOUtil {
     }
 
     public static String getUserTenantDomain() {
-
-        if (userTenantDomainThreadLocal == null) {
-            // this is the default behavior.
-            return null;
-        }
 
         return userTenantDomainThreadLocal.get();
     }
@@ -487,7 +470,6 @@ public class SAMLSSOUtil {
         }
 
     }
-
 
     public static String decodeForPost(String encodedStr)
             throws IdentityException {
@@ -785,7 +767,7 @@ public class SAMLSSOUtil {
                                                String sessionId) throws IdentityException {
 
         doBootstrap();
-        String assertionBuilderClass = null;
+        String assertionBuilderClass;
         try {
             assertionBuilderClass = IdentityUtil.getProperty("SSOService.SAMLSSOAssertionBuilder").trim();
             if (StringUtils.isBlank(assertionBuilderClass)) {
@@ -1793,7 +1775,6 @@ public class SAMLSSOUtil {
     }
 
     public static void setIdPInitSSOAuthnRequestProcessor(String idPInitSSOAuthnRequestProcessor) {
-        SAMLSSOUtil.idPInitSSOAuthnRequestProcessorClassName = idPInitSSOAuthnRequestProcessor;
     }
 
     public static IdPInitSSOAuthnRequestProcessor getIdPInitSSOAuthnRequestProcessor() {


### PR DESCRIPTION
Fix wso2/product-is#4776

The issue was caused by the assertion being too large for the **VARCHAR** column **SAML2_ASSERTION**. Increasing the column size is fine with most databases. However, Oracle varchar datatype only allows a maximum of 4000 characters. Because of this reason, we will be using an additional column to store the SAML2 assertion as a Blob. The existing column will not be modified due to backward compatibility reasons.

**There are three scenarios that can be affected by this implementation**

1. IS 5.8.0 is used along with the modified database schema
2. IS 5.8.0 is pointed to an old database where IDN_SAML2_ASSERTION_STORE table doesn't have this additional column. In this case, we will be checking if this additional column exists and act accordingly.
3. User migrates to the new version