### PR TITLE
Fix NPE when SessionIndex is not sent in LogoutRequest

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
@@ -111,6 +111,12 @@ public class SPInitLogoutRequestProcessor implements SPInitSSOLogoutRequestProce
                     .getPersistenceManager();
             String sessionIndex = logoutRequest.getSessionIndexes().size() > 0 ? logoutRequest
                     .getSessionIndexes().get(0).getSessionIndex() : null;
+            /* 'SessionIndex' attribute can be optional in the SAML logout request. In that case we need to retrieve
+            the session index from session Id. */
+            if (sessionIndex == null) {
+                sessionIndex = SSOSessionPersistenceManager.getPersistenceManager().getSessionIndexFromTokenId
+                        (sessionId);
+            }
             SessionInfoData sessionInfoData = ssoSessionPersistenceManager.getSessionInfo(sessionIndex);
             String subject = sessionInfoData.getSubject(issuer);
             Map<String, SAMLSSOServiceProviderDO> sessionsList = sessionInfoData.getServiceProviderList();


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/4895

**Description** : As per the [specification](https://www.oasis-open.org/committees/download.php/35711/sstc-saml-core-errata-2.0-wd-06-diff.pdf), SessionIndex attribute is not mandatory in LogoutRequest. See "3.7.1 Element " and "3.7.3.1 Session Participant Rules" sections of spec.
However if we receive a logout request without a SessionIndex, a NPE is thrown and the logout flow breaks.

**Solution** : As a possible solution for this issue, since we are storing a mapping between the session ID (ssoTokenId cookie value) and the SessionIndex attribute in server side, if the 'SessionIndex' in the logout request is null, we can retrieve the corresponding SessionIndex of the user through the cookie using the SSOSessionPersistenceManager.getPersistenceManager().getSessionIndexFromTokenId method similarly to the approach used in IDP intiated logout. 