### PR TITLE
Fix #4716:[SAML SSO] Destination validation failed with proxy port enabled in an Nginx fronted deployment

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServletTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServletTest.java
@@ -1,0 +1,56 @@
+package org.wso2.carbon.identity.sso.saml.servlet;
+
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOAuthnReqDTO;
+import org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtil;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertEquals;
+
+@PrepareForTest({SAMLSSOUtil.class})
+public class SAMLSSOProviderServletTest extends PowerMockTestCase {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private SAMLSSOAuthnReqDTO authnReqDTO;
+
+    @DataProvider(name = "testValidateDestination")
+    public static Object[][] testValidateDestination() {
+
+        return new Object[][]{
+                {"https://localhost:9443/samlsso", Collections.singletonList("https://localhost:9443/samlsso"), true},
+                {"https://localhost/samlsso", Collections.singletonList("https://localhost:443/samlsso"), true},
+                {"http://localhost/samlsso", Collections.singletonList("http://localhost:80/samlsso"), true},
+        };
+    }
+
+    @Test(dataProvider = "testValidateDestination")
+    public void testDestinationValidate(String providedDestinationUrl, List<String> idpDestinationUrls, boolean expected)
+            throws Exception {
+
+        mockStatic(SAMLSSOUtil.class);
+        when(SAMLSSOUtil.getDestinationFromTenantDomain(anyString())).thenReturn(idpDestinationUrls);
+        when(authnReqDTO.getDestination()).thenReturn(providedDestinationUrl);
+
+        SAMLSSOProviderServlet servlet = new SAMLSSOProviderServlet();
+        boolean isValid = servlet.isDestinationUrlValid(authnReqDTO, request, response);
+
+        assertEquals(isValid, expected);
+    }
+}


### PR DESCRIPTION
- Resolves wso2/product-is#4716
Even though the SAML service is running on 443 port, destination URL received from IDP config contains 443 port appended. In that case, if the destination URL sent from the request doesn't contain the 443 port appended(even if it is https), destination validation fails. Hence we compare both URLs(443 appended and not) with destination URLs received from IDP config.