### PR TITLE
Fix #5077:SAML logout request gives a Null Pointer Exception when SP certificate not configured in UI

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
@@ -174,14 +174,10 @@ public class SPInitLogoutRequestProcessor implements SPInitSSOLogoutRequestProce
     private void setX509Certificate(String issuer, SAMLSSOServiceProviderDO logoutReqIssuer) {
 
         try {
-            String tenant = logoutReqIssuer.getTenantDomain();
-            ServiceProvider serviceProvider = SAMLSSOUtil.getApplicationMgtService().
-                    getServiceProviderByClientId(issuer, SAMLSSOConstants.INBOUND_AUTH_TYPE_SAML, tenant);
-            String cert = serviceProvider.getCertificateContent();
-            X509Certificate certificate = (X509Certificate) IdentityUtil.convertPEMEncodedContentToCertificate(cert);
-            logoutReqIssuer.setX509Certificate(certificate);
+            SAMLSSOServiceProviderDO serviceProviderConfigs = getServiceProviderConfig(issuer);
+            logoutReqIssuer.setX509Certificate(serviceProviderConfigs.getX509Certificate());
 
-        } catch (IdentityApplicationManagementException | CertificateException e) {
+        } catch (IdentityException e) {
             String errorMessage = String.format("An error occurred while retrieving the application " +
                     "certificate for file based SAML service provider with the issuer name '%s'. " +
                     "The service provider will NOT be loaded.", issuer);


### PR DESCRIPTION
Fix wso2/product-is#5077
In SLO it only considers the certificate provided at the time time of SP configuration. But when configuring a SAML SP we have to define a cert alias and it should be considered when validating the signature. In SSO this works as expected.
This fix makes SLO flow consistent with the SSO