### PR TITLE
Fixing issue: ACR not returned in SAML2 response

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -81,6 +81,7 @@ public class SAMLSSOConstants {
     public static final String REQUESTED_ATTRIBUTES = "requested_attributes";
 
     public static final String AUTHN_CONTEXT_CLASS_REF = "AuthnContextClassRef";
+    public static final String AUTHN_INSTANT = "AuthnInstant";
     public static final String SAML_SSO_ENCRYPTOR_CONFIG_PATH = "SSOService.SAMLSSOEncrypter";
     public static final String SAML2_HTTP_REDIRECT_SIGNATURE_VALIDATOR_CLASS_NAME = "SSOService.SAML2HTTPRedirectSignatureValidator";
     public static final String SAMLSSO_SIGNER_CLASS_NAME = "SSOService.SAMLSSOSigner";

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
@@ -250,6 +250,15 @@ public class DefaultSAMLAssertionBuilder implements SAMLAssertionBuilder {
                             idpEntityId = (String) passThroughData.get(IdentityApplicationConstants.Authenticator
                                     .SAML2SSO.IDP_ENTITY_ID);
                         }
+                        DateTime applicableAuthnInstant = (DateTime) passThroughData.get(
+                                SAMLSSOConstants.AUTHN_INSTANT);
+                        if (applicableAuthnInstant == null) {
+                            if(log.isDebugEnabled()) {
+                                log.debug(
+                                        "Treating AuthnInstant as current time, as it is not found in the pass-through data");
+                            }
+                            applicableAuthnInstant = authnInstant;
+                        }
                         for (String authnContextClassRef : authnContextClassRefList) {
                             if (StringUtils.isNotBlank(authnContextClassRef)) {
                                 if (log.isDebugEnabled()) {
@@ -257,7 +266,7 @@ public class DefaultSAMLAssertionBuilder implements SAMLAssertionBuilder {
                                             "AuthenticatingAuthority:" + idpEntityId + " in the AuthnStatement");
                                 }
                                 samlAssertion.getAuthnStatements().add(getAuthnStatement(authReqDTO, sessionId,
-                                        authnContextClassRef, authnInstant, idpEntityId));
+                                        authnContextClassRef, applicableAuthnInstant, idpEntityId));
                             }
                         }
                     }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOReqValidationResponseDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOReqValidationResponseDTO.java
@@ -318,8 +318,11 @@ public class SAMLSSOReqValidationResponseDTO implements Serializable {
     /**
      * Set Authentication Context Class Reference.
      *
-     * @param authenticationContextClassRefList list of Authentication Context Class Reference
+     * @param authenticationContextClassRefList list of Authentication Context Class Reference.
+     * @deprecated on 2019-July-03
+     * as it is wrong to set internal state. Please use addAuthenticationContextClassRef () instead.
      */
+    @Deprecated
     public void setAuthenticationContextClassRefList(List<SAMLAuthenticationContextClassRefDTO>
                                                              authenticationContextClassRefList) {
 

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -22,7 +22,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opensaml.saml2.core.LogoutRequest;
 import org.opensaml.saml2.core.LogoutResponse;
-import org.opensaml.saml2.core.impl.LogoutRequestImpl;
 import org.opensaml.xml.XMLObject;
 import org.owasp.encoder.Encode;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -31,6 +30,7 @@ import org.wso2.carbon.identity.application.authentication.framework.Authenticat
 import org.wso2.carbon.identity.application.authentication.framework.CommonAuthenticationHandler;
 import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationRequestCacheEntry;
 import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationResultCacheEntry;
+import org.wso2.carbon.identity.application.authentication.framework.context.SessionAuthHistory;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationContextProperty;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationRequest;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationResult;
@@ -773,7 +773,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         sessionDTO.setPassiveAuth(signInRespDTO.isPassive());
         sessionDTO.setValidationRespDTO(signInRespDTO);
         sessionDTO.setIdPInitSSO(signInRespDTO.isIdPInitSSO());
-        sessionDTO.setAuthenticationContextClassRefList(signInRespDTO.getAuthenticationContextClassRefList());
+        addRequestedAuthenticationContextClassReferences(sessionDTO, signInRespDTO);
         sessionDTO.setRequestedAttributes(signInRespDTO.getRequestedAttributes());
         sessionDTO.setRequestedAuthnContextComparison(signInRespDTO.getRequestedAuthnContextComparison());
         sessionDTO.setProperties(signInRespDTO.getProperties());
@@ -818,6 +818,15 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         //Add user atributes
         req.setAttribute(SAMLSSOConstants.REQUESTED_ATTRIBUTES, signInRespDTO.getRequestedAttributes());
         sendRequestToFramework(req, resp, sessionDataKey, FrameworkConstants.RequestType.CLAIM_TYPE_SAML_SSO);
+    }
+
+    private void addRequestedAuthenticationContextClassReferences(SAMLSSOSessionDTO sessionDTO,
+                                                                  SAMLSSOReqValidationResponseDTO signInRespDTO) {
+
+        if (signInRespDTO.getAuthenticationContextClassRefList() != null) {
+            signInRespDTO.getAuthenticationContextClassRefList().forEach(
+                    a -> sessionDTO.addAuthenticationContextClassRef(a));
+        }
     }
 
     private void addAuthenticationRequestToRequest(HttpServletRequest request,AuthenticationRequestCacheEntry authRequest){
@@ -1065,6 +1074,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
 
         SAMLSSOAuthnReqDTO authnReqDTO = new SAMLSSOAuthnReqDTO();
         populateAuthnReqDTOWithCachedSessionEntry(authnReqDTO, sessionDTO);
+        populateAuthenticationContextClassRefResult(req, sessionDTO, authnReqDTO);
 
         String tenantDomain = authnReqDTO.getTenantDomain();
         String issuer = authnReqDTO.getIssuer();
@@ -1197,8 +1207,57 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         }
     }
 
+<<<<<<< HEAD
     private void handleLogoutResponseFromFramework(HttpServletRequest request, HttpServletResponse response,
                                                    SAMLSSOSessionDTO sessionDTO)
+=======
+    /**
+     * Reads the ACR from the framework and associate it to the ACR to be returned.
+     *
+     * @param req         Original or wrapped HttpServletRequest
+     * @param sessionDTO  the SAML Session DTO
+     * @param authnReqDTO the SAML Request DTO
+     */
+    private void populateAuthenticationContextClassRefResult(HttpServletRequest req, SAMLSSOSessionDTO sessionDTO,
+                                                             SAMLSSOAuthnReqDTO authnReqDTO) {
+
+        SessionAuthHistory sessionAuthHistory = (SessionAuthHistory) req.getAttribute(
+                FrameworkConstants.SESSION_AUTH_HISTORY);
+        if (sessionAuthHistory != null && sessionAuthHistory.getSelectedAcrValue() != null) {
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Found the selected ACR value from the framework as : " +
+                                sessionAuthHistory.getSelectedAcrValue() +
+                                " , Hence creating the AuthenticationContextProperty");
+            }
+            List<AuthenticationContextProperty> authenticationContextProperties = authnReqDTO
+                    .getIdpAuthenticationContextProperties().get(SAMLSSOConstants.AUTHN_CONTEXT_CLASS_REF);
+            List<String> acrListFromFramework = new ArrayList<>();
+            acrListFromFramework.add(sessionAuthHistory.getSelectedAcrValue());
+            if (authenticationContextProperties == null) {
+                authenticationContextProperties = new ArrayList<>();
+                authnReqDTO.getIdpAuthenticationContextProperties().put(SAMLSSOConstants.AUTHN_CONTEXT_CLASS_REF,
+                        authenticationContextProperties);
+            }
+            Map<String, Object> passThroughData = new HashMap<>();
+            AuthenticationContextProperty acrFromFramework = new AuthenticationContextProperty(
+                    IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID,
+                    IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID,
+                    passThroughData);
+            passThroughData.put(SAMLSSOConstants.AUTHN_CONTEXT_CLASS_REF, acrListFromFramework);
+            passThroughData.put(SAMLSSOConstants.AUTHN_INSTANT, sessionAuthHistory.getSessionCreatedTime());
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Setting the AuthnInst as session create time : " + sessionAuthHistory.getSessionCreatedTime());
+            }
+
+            authenticationContextProperties.add(acrFromFramework);
+        }
+    }
+
+    private void handleLogoutResponseFromFramework(HttpServletRequest request,
+                                                   HttpServletResponse response, SAMLSSOSessionDTO sessionDTO)
+>>>>>>> 6a159461... Fixing issue: ACR not returned in SAML2 response
             throws ServletException, IOException, IdentityException {
 
         SAMLSSOReqValidationResponseDTO validationResponseDTO = sessionDTO.getValidationRespDTO();

--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
     <properties>
 
         <carbon.kernel.version>4.5.0-m1</carbon.kernel.version>
-        <carbon.identity.framework.version>5.13.4</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.13.22</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.13.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/5823

Add following to the docs at https://docs.wso2.com/display/IS580/Working+with+ACR+and+AMR

## Handling the ACR in SAML Assertion
You can define ordered list of the “ACR Values” acceptable in the “service provider”  in In Authentication Script. There is an inbuilt function  “selectAcrFrom”, which evaluates the best (strongest) ACR from the received ACR List and the configured ACR List. The function “context.selectedAcr” should be used to set the value of the ACR to be returned to the caller.
```
var supportedAcrValues = ['urn:oasis:names:tc:SAML:2.0:classes:Kerberos', 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password', urn:federation:authentication:windows'];

…
…

var selectedAcr = selectAcrFrom(context, supportedAcrValues);
context.selectedAcr = selectedAcr;

```
