### PR TITLE
Fix metadata file upload for SAML configurations.

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml.ui/src/main/java/org/wso2/carbon/identity/sso/saml/ui/client/SamlSPMetadataUploadExecutor.java
+++ b/components/org.wso2.carbon.identity.sso.saml.ui/src/main/java/org/wso2/carbon/identity/sso/saml/ui/client/SamlSPMetadataUploadExecutor.java
@@ -50,7 +50,7 @@ public class SamlSPMetadataUploadExecutor extends AbstractFileUploadExecutor {
         String webContext = (String) httpServletRequest.getAttribute(CarbonConstants.WEB_CONTEXT);
         String serverURL = (String) httpServletRequest.getAttribute(CarbonConstants.SERVER_URL);
         String cookie = (String) httpServletRequest.getAttribute(ServerConstants.ADMIN_SERVICE_COOKIE);
-        String spName = httpServletRequest.getParameter("application-sp-name");
+        String spName = getFormFieldsMap().get("application-sp-name").get(0);
         log.info(spName);
         errorRedirectionPage = getContextRoot(httpServletRequest) + "/" + webContext
                 + "/sso-saml/add_service_provider.jsp?spName=" + spName;

--- a/components/org.wso2.carbon.identity.sso.saml.ui/src/main/java/org/wso2/carbon/identity/sso/saml/ui/client/SamlSPMetadataUploadExecutor.java
+++ b/components/org.wso2.carbon.identity.sso.saml.ui/src/main/java/org/wso2/carbon/identity/sso/saml/ui/client/SamlSPMetadataUploadExecutor.java
@@ -1,20 +1,20 @@
 /*
-  * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-  *
-  * WSO2 Inc. licenses this file to you under the Apache License,
-  * Version 2.0 (the "License"); you may not use this file except
-  * in compliance with the License.
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing,
-  * software distributed under the License is distributed on an
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  * KIND, either express or implied.  See the License for the
-  * specific language governing permissions and limitations
-  * under the License.
-  */
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.identity.sso.saml.ui.client;
 
@@ -40,17 +40,19 @@ import java.util.Map;
 public class SamlSPMetadataUploadExecutor extends AbstractFileUploadExecutor {
 
     private static final String[] ALLOWED_FILE_EXTENSIONS = new String[]{".xml"};
+    private static final String APPLICATION_SP_NAME_KEY = "application-sp-name";
 
     private String errorRedirectionPage;
 
     @Override
     public boolean execute(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse)
             throws CarbonException, IOException {
+
         log.info("Uploading");
         String webContext = (String) httpServletRequest.getAttribute(CarbonConstants.WEB_CONTEXT);
         String serverURL = (String) httpServletRequest.getAttribute(CarbonConstants.SERVER_URL);
         String cookie = (String) httpServletRequest.getAttribute(ServerConstants.ADMIN_SERVICE_COOKIE);
-        String spName = getFormFieldsMap().get("application-sp-name").get(0);
+        String spName = getFormFieldsMap().get(APPLICATION_SP_NAME_KEY).get(0);
         log.info(spName);
         errorRedirectionPage = getContextRoot(httpServletRequest) + "/" + webContext
                 + "/sso-saml/add_service_provider.jsp?spName=" + spName;

--- a/components/org.wso2.carbon.identity.sso.saml.ui/src/main/resources/web/sso-saml/add_service_provider.jsp
+++ b/components/org.wso2.carbon.identity.sso.saml.ui/src/main/resources/web/sso-saml/add_service_provider.jsp
@@ -1969,6 +1969,9 @@
                   id="uploadServiceProvider" name="uploadServiceProvider" target="_self" enctype="multipart/form-data"
                   onsubmit="return doValidation();">
 
+                <input type="hidden" id="application-sp-name" name="application-sp-name"
+                      value="<%=Encode.forHtmlAttribute(applicationSPName)%>"/>
+
                 <table class="styledLeft" width="100%">
                     <thead>
                     <tr>


### PR DESCRIPTION
- `httpServeletRequest.getParameter("application-sp-name")` returns `null` since that parameter is inside the form fields as `getFormFieldsMap().get("application-sp-name").get(0)`.

Fixes: [https://github.com/wso2/product-is/issues/7679](https://github.com/wso2/product-is/issues/7679)