### PR TITLE
Tenant qualify /samlsso endpoint for inbound requests

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -220,6 +220,12 @@
         <dependency>
             <groupId>org.opensaml</groupId>
             <artifactId>opensaml-storage-impl</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opensaml</groupId>
@@ -249,11 +255,7 @@
             <groupId>net.shibboleth.utilities</groupId>
             <artifactId>java-support</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-testng</artifactId>
@@ -264,6 +266,13 @@
             <artifactId>powermock-api-mockito</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -2585,7 +2585,7 @@ public class SAMLSSOUtil {
 
         if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && StringUtils.isNotBlank(urlFromConfig)) {
             if (log.isDebugEnabled()) {
-                log.debug("Resolved URL:" + urlFromConfig + " from file configuration for default url context:" +
+                log.debug("Resolved URL:" + urlFromConfig + " from file configuration for default url context: " +
                         defaultUrlContext);
             }
             return urlFromConfig;

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -69,7 +69,10 @@ import org.wso2.carbon.identity.application.common.util.IdentityApplicationManag
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.IdentityRegistryResources;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.model.SAMLSSOServiceProviderDO;
 import org.wso2.carbon.identity.core.persistence.IdentityPersistenceManager;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -642,11 +645,15 @@ public class SAMLSSOUtil {
                 IdentityApplicationConstants.Authenticator.SAML2SSO.NAME, IdentityApplicationConstants.Authenticator
                         .SAML2SSO.DESTINATION_URL_PREFIX));
         if (destinationURLs.size() == 0) {
-            String configDestination = IdentityUtil.getProperty(IdentityConstants.ServerConfig.SSO_IDP_URL);
-            if (StringUtils.isBlank(configDestination)) {
-                configDestination = IdentityUtil.getServerURL(SAMLSSOConstants.SAMLSSO_URL, true, true);
+
+            String destinationURL = resolveUrl(SAMLSSOConstants.SAMLSSO_URL, IdentityUtil.getProperty
+                    (IdentityConstants.ServerConfig.SSO_IDP_URL));
+            destinationURLs.add(destinationURL);
+
+            if (log.isDebugEnabled()) {
+                log.debug("No destination URLs configured for resident IdP in tenant: " + tenantDomain + ". Resolved " +
+                        "default destination URL: " + destinationURL);
             }
-            destinationURLs.add(configDestination);
         }
 
         return destinationURLs;
@@ -2572,5 +2579,18 @@ public class SAMLSSOUtil {
             }
         }
         return null;
+    }
+
+    private static String resolveUrl(String defaultUrlContext, String urlFromConfig) throws URLBuilderException {
+
+        if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && StringUtils.isNotBlank(urlFromConfig)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Resolved URL:" + urlFromConfig + " from file configuration for default url context:" +
+                        defaultUrlContext);
+            }
+            return urlFromConfig;
+        }
+
+        return ServiceURLBuilder.create().addPath(defaultUrlContext).build().getAbsolutePublicURL();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -526,7 +526,7 @@
 
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
-        <carbon.identity.framework.version>5.16.119</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.17.43</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Relates to wso2/product-is#8139

**Proposed changes in this pull request**
- Fix samlsso endpoint to accept inbound requests with tenant in path.
- Update unit tests to verify destination URL resolution.

