### PR TITLE
Send tenantDomain in the logout request to framework

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -903,6 +903,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         authenticationRequest.setRequestQueryParams(request.getParameterMap());
         authenticationRequest.setCommonAuthCallerPath(selfPath);
         authenticationRequest.setPost(isPost);
+        authenticationRequest.setTenantDomain(SAMLSSOUtil.getTenantDomainFromThreadLocal());
 
         if (signInRespDTO != null) {
             authenticationRequest.setRelyingParty(signInRespDTO.getIssuer());


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/8186

When the tenant domain is not passed in the logout request to the framework, the framework cannot send SLO to authenticated IDPs.

When it looks for IDPs in the tenant domain (which is always carbon.super), they do not exist leading to the logout requests to respective IDPs being not sent[1].

[1] https://github.com/wso2/carbon-identity-framework/blob/11fe8ca1e0efccc755de607eae1d211a917c76cb/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java#L154-L157