### PR TITLE
Fix null pointer exception when authentication result is null

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -1231,8 +1231,11 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                                                              SAMLSSOSessionDTO sessionDTO,
                                                              SAMLSSOAuthnReqDTO authnReqDTO) {
 
-        SessionAuthHistory sessionAuthHistory = (SessionAuthHistory) authenticationResult.getProperty(
-                FrameworkConstants.SESSION_AUTH_HISTORY);
+        SessionAuthHistory sessionAuthHistory = null;
+        if (authenticationResult != null) {
+            sessionAuthHistory = (SessionAuthHistory) authenticationResult.getProperty(
+                    FrameworkConstants.SESSION_AUTH_HISTORY);
+        }
 
         if (sessionAuthHistory != null && sessionAuthHistory.getSelectedAcrValue() != null) {
             if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServletTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServletTest.java
@@ -5,8 +5,11 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationResult;
 import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOAuthnReqDTO;
+import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOSessionDTO;
 import org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtil;
+import org.powermock.reflect.Whitebox;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -17,6 +20,7 @@ import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 @PrepareForTest({SAMLSSOUtil.class})
 public class SAMLSSOProviderServletTest extends PowerMockTestCase {
@@ -29,6 +33,15 @@ public class SAMLSSOProviderServletTest extends PowerMockTestCase {
 
     @Mock
     private SAMLSSOAuthnReqDTO authnReqDTO;
+
+    @Mock
+    private SAMLSSOProviderServlet samlssoProviderServlet;
+
+    @Mock
+    private SAMLSSOSessionDTO samlssoSessionDTO;
+
+    @Mock
+    private SAMLSSOAuthnReqDTO samlssoAuthnReqDTO;
 
     @DataProvider(name = "testValidateDestination")
     public static Object[][] testValidateDestination() {
@@ -52,5 +65,17 @@ public class SAMLSSOProviderServletTest extends PowerMockTestCase {
         boolean isValid = servlet.isDestinationUrlValid(authnReqDTO, request, response);
 
         assertEquals(isValid, expected);
+    }
+
+    @Test
+    public void testNullAuthenticationResult() throws Exception {
+
+        try {
+            Whitebox.invokeMethod(samlssoProviderServlet, "populateAuthenticationContextClassRefResult",
+                    (AuthenticationResult) null, samlssoSessionDTO, samlssoAuthnReqDTO);
+        } catch (NullPointerException e) {
+            fail("Authentication Result can be null. Check for null value should be added to avoid Null pointer " +
+                    "exceptions.");
+        }
     }
 }


### PR DESCRIPTION
Fix: wso2/product-is#8888

The issue occurs when passive request goes to /samlsso endpoint. This request does not expected to create a authentication result object. Hence it is expected that the authenticationResult object being null in method populateAuthenticationContextClassRefResult() method. Hence the null pointer needs to be handled.