### PR TITLE
Enable assertion signing by default

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -49,6 +49,7 @@ import java.util.Map;
 public class SAMLSSOService {
 
     public static boolean isOpenIDLoginAccepted() {
+
         if (IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_OPENID_LOGIN) != null &&
                 !"".equals(IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_OPENID_LOGIN).trim())) {
             return Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_OPENID_LOGIN).trim());
@@ -58,6 +59,7 @@ public class SAMLSSOService {
     }
 
     public static boolean isSAMLSSOLoginAccepted() {
+
         if (IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_SAMLSSO_LOGIN) != null &&
                 !"".equals(IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_SAMLSSO_LOGIN).trim())) {
             return Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_SAMLSSO_LOGIN).trim());

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -49,7 +49,6 @@ import java.util.Map;
 public class SAMLSSOService {
 
     public static boolean isOpenIDLoginAccepted() {
-
         if (IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_OPENID_LOGIN) != null &&
                 !"".equals(IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_OPENID_LOGIN).trim())) {
             return Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_OPENID_LOGIN).trim());
@@ -59,7 +58,6 @@ public class SAMLSSOService {
     }
 
     public static boolean isSAMLSSOLoginAccepted() {
-
         if (IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_SAMLSSO_LOGIN) != null &&
                 !"".equals(IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_SAMLSSO_LOGIN).trim())) {
             return Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.ServerConfig.ACCEPT_SAMLSSO_LOGIN).trim());

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
@@ -248,7 +248,11 @@ public class SAMLSSOConfigAdmin {
         serviceProviderDO.setSloRequestURL(serviceProviderDTO.getSloRequestURL());
         serviceProviderDO.setLoginPageURL(serviceProviderDTO.getLoginPageURL());
         serviceProviderDO.setDoSignResponse(serviceProviderDTO.isDoSignResponse());
-        serviceProviderDO.setDoSignAssertions(serviceProviderDTO.isDoSignAssertions());
+        /*
+        According to the spec, "The <Assertion> element(s) in the <Response> MUST be signed". Therefore we should not
+        reply on any property to decide this behaviour. Hence the property is set to sign by default.
+        */
+        serviceProviderDO.setDoSignAssertions(true);
         serviceProviderDO.setNameIdClaimUri(serviceProviderDTO.getNameIdClaimUri());
         serviceProviderDO.setSigningAlgorithmUri(serviceProviderDTO.getSigningAlgorithmURI());
         serviceProviderDO.setDigestAlgorithmUri(serviceProviderDTO.getDigestAlgorithmURI());
@@ -352,7 +356,11 @@ public class SAMLSSOConfigAdmin {
         serviceProviderDTO.setSloRequestURL(serviceProviderDO.getSloRequestURL());
         serviceProviderDTO.setSloResponseURL(serviceProviderDO.getSloResponseURL());
         serviceProviderDTO.setDoSignResponse(serviceProviderDO.isDoSignResponse());
-        serviceProviderDTO.setDoSignAssertions(serviceProviderDO.isDoSignAssertions());
+        /*
+        According to the spec, "The <Assertion> element(s) in the <Response> MUST be signed". Therefore we should not
+        reply on any property to decide this behaviour. Hence the property is set to sign by default.
+        */
+        serviceProviderDTO.setDoSignAssertions(true);
         serviceProviderDTO.setNameIdClaimUri(serviceProviderDO.getNameIdClaimUri());
         serviceProviderDTO.setSigningAlgorithmURI(serviceProviderDO.getSigningAlgorithmUri());
         serviceProviderDTO.setDigestAlgorithmURI(serviceProviderDO.getDigestAlgorithmUri());
@@ -427,7 +435,11 @@ public class SAMLSSOConfigAdmin {
                 }
 
                 providerDTO.setDoSignResponse(providerDO.isDoSignResponse());
-                providerDTO.setDoSignAssertions(providerDO.isDoSignAssertions());
+                /*
+                According to the spec, "The <Assertion> element(s) in the <Response> MUST be signed". Therefore we
+                should not reply on any property to decide this behaviour. Hence the property is set to sign by default.
+                */
+                providerDTO.setDoSignAssertions(true);
                 providerDTO.setDoSingleLogout(providerDO.isDoSingleLogout());
                 providerDTO.setDoFrontChannelLogout(providerDO.isDoFrontChannelLogout());
                 providerDTO.setFrontChannelLogoutBinding(providerDO.getFrontChannelLogoutBinding());


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9357

According to the SAML spec, `The <Assertion> element(s) in the <Response> MUST be signed`. Therefore we should not reply on any property to decide this behaviour. Hence assertions are set to be signed by default.