### PR TITLE
Deprecating doSingleLogout method since there are two overloaded methods in SAMLSSOService

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -189,15 +189,23 @@ public class SAMLSSOService {
      * @param sessionId
      * @return
      * @throws IdentityException
+     * @deprecated use {@link #invalidateSession(String)} instead.
      */
     public SAMLSSOReqValidationResponseDTO doSingleLogout(String sessionId)
             throws IdentityException {
+       return invalidateSession(sessionId);
+    }
+
+    /**
+     * Invalidates the SSO session for the given session ID.
+     * @param sessionId sessionId.
+     * @return SAMLSSOReqValidationResponseDTO.
+     * @throws IdentityException
+     */
+    public SAMLSSOReqValidationResponseDTO invalidateSession(String sessionId) throws IdentityException {
+
         SPInitLogoutRequestProcessor logoutReqProcessor = SAMLSSOUtil.getSPInitLogoutRequestProcessor();
-        SAMLSSOReqValidationResponseDTO validationResponseDTO =
-                logoutReqProcessor.process(null,
-                        sessionId,
-                        null);
-        return validationResponseDTO;
+        return logoutReqProcessor.process(null, sessionId, null);
     }
 
     /**


### PR DESCRIPTION


Partial fix of https://github.com/wso2/product-is/issues/10201

- This is to fix the below warn logs
`WARN {org.apache.axis2.description.java2wsdl.DefaultSchemaGenerator} - We don't support method overloading. Ignoring [doSingleLogout]`

- There are two overloaded doSingleLogout(..) methods in SAMLSSOService.java. The above warn logs getting printed when the wsdlschema creation of second overloaded method  `doSingleLogout(String sessionId, String issuer) `. The created wsdl file has only `doSingleLogout(String sessionId)` and the second  `doSingleLogout(String sessionId, String issuer) ` method is ingored by the service.

To overcome this issue, we added a doc comment for deprecate the `doSingleLogout(String sessionId)`  method and rename that method. Need to deprecate this method over the time.
