### PR TITLE
Fix issue of samlssoTokenIdCookie expiry time

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -1399,7 +1399,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         ServletCookie samlssoTokenIdCookie = new ServletCookie(SAML_SSO_TOKEN_ID_COOKIE, sessionId);
         IdentityCookieConfig samlssoTokenIdCookieConfig = IdentityUtil
                 .getIdentityCookieConfig(SAML_SSO_TOKEN_ID_COOKIE);
-        int defaultMaxAge = IdPManagementUtil.getIdleSessionTimeOut(tenantDomain) * 60;
+        int defaultMaxAge = IdPManagementUtil.getIdleSessionTimeOut(tenantDomain);
 
         samlssoTokenIdCookie.setSecure(true);
         samlssoTokenIdCookie.setHttpOnly(true);


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/6845

### Approach
IdPManagementUtil.getIdleSessionTimeOut(tenantDomain) returns idle session timeout is seconds. https://github.com/wso2/carbon-identity-framework/blob/d17b1f4649587dc4882ccda56d6783d69fcbddb4/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java#L96

If  defaultMaxAge is calculated as :
`int defaultMaxAge = IdPManagementUtil.getIdleSessionTimeOut(tenantDomain);`
the expiry time of the cookie is 60 times seconds longer than the idle session timeout. (eg: if idlesession time out = 2 min, cookie max age = 2hrs). So, it doesn't not get cleared after a session time out.

This PR modifies the calculation by removing multiplying y 60.