### PR TITLE
Update the certificate in the session while creating SAML metadata via URL

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml.ui/src/main/resources/web/sso-saml/upload_service_provider_from_url_finish.jsp
+++ b/components/org.wso2.carbon.identity.sso.saml.ui/src/main/resources/web/sso-saml/upload_service_provider_from_url_finish.jsp
@@ -62,6 +62,13 @@
         } else {
             attributeConsumingServiceIndex = "";
         }
+    
+        // Store the certificate contained inside the metadata from URL, in the session.
+        // This will be used by service provider update operation to know the certificate came inside SAML
+        // metadata from URL.
+        request.getSession().setAttribute(SAMLSSOUIConstants.SESSION_ATTRIBUTE_NAME_APPLICATION_CERTIFICATE,
+                serviceProviderDTO.getCertificateContent());
+        
         samlSsoServuceProviderConfigBean.clearBean();
         String message = resourceBundle.getString("sp.added.successfully");
         CarbonUIMessage.sendCarbonUIMessage(message, CarbonUIMessage.INFO, request);


### PR DESCRIPTION
Fixes: https://github.com/wso2/product-is/issues/10566

The certificate information in the service provider creation window is loaded from the session in the HttpServeletRequest. When uploading the SAML metadata file, the certificate information is added to the session thus it is correctly loaded in the SP creation window. However, this is missed when metadata is created via the URL. 

This pull request adds that missing logic(ported from 27b906a) in the corresponding place.