### PR TITLE
Improve error message for authentication request processing issues

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitSSOAuthnRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitSSOAuthnRequestProcessor.java
@@ -202,7 +202,7 @@ public class IdPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor
             SAMLSSORespDTO errorResp =
                     buildErrorResponse(authnReqDTO.getId(),
                             statusCodes,
-                            "Authentication Failure, invalid username or password.", null);
+                            "Error processing the authentication request.", null);
             errorResp.setLoginPageURL(authnReqDTO.getLoginPageURL());
             errorResp.setAssertionConsumerURL(authnReqDTO.getAssertionConsumerURL());
             return errorResp;

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
@@ -187,7 +187,7 @@ public class SPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor{
 
             SAMLSSORespDTO errorResp =
                     buildErrorResponse(authnReqDTO.getId(), statusCodes,
-                            "Authentication Failure, invalid username or password.", null);
+                            "Error processing the authentication request.", null);
             errorResp.setLoginPageURL(authnReqDTO.getLoginPageURL());
             errorResp.setAssertionConsumerURL(authnReqDTO.getAssertionConsumerURL());
             return errorResp;


### PR DESCRIPTION
Following SAML response is returned when there is an issue with processing the SAML authentication request. Ref [1], [2].

```
	<saml2p:Status>
		<saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder">
			<saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"/></saml2p:StatusCode>
		<saml2p:StatusMessage>Authentication Failure, invalid username or password.</saml2p:StatusMessage>
	</saml2p:Status>
```
This message is misguiding and makes troubleshooting harder.

This PR improves the error message.


[1] https://github.com/wso2-extensions/identity-inbound-auth-saml/blob/0ccfaaa853f30e700884c5bf5f47111b91724531/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java#L181-L190
[2] https://github.com/wso2-extensions/identity-inbound-auth-saml/blob/0ccfaaa853f30e700884c5bf5f47111b91724531/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitSSOAuthnRequestProcessor.java#L195-L205
