### PR TITLE
fixing redirectURL for Single Logout 

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -2032,7 +2032,8 @@ public class SAMLSSOProviderServlet extends HttpServlet {
             throw new IdentityException("Error in compressing the SAML request message.", e);
         }
 
-        String redirectUrl = logoutRequest.getDestination() + "?" + httpQueryString.toString();
+        String redirectUrl = FrameworkUtils.appendQueryParamsStringToUrl(logoutRequest.getDestination(),
+                httpQueryString.toString());
 
         return redirectUrl;
     }


### PR DESCRIPTION
This PR fixes wso2/product-is#11823

**Description of the Issue**
--
Front channel HTTP-redirect binding SLO URL generated is wrong.
**```https://www.example.com/index.php?param1=xyz&param2=abc?SAMLRequest= ```**

**Cause**
--
URL generation does not considers existing query parameters in the URL

**Fix**
--
**Append** the SAML Request. 