### PR TITLE
Enable tenanted paths for samlssoTokenId cookie

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLInboundSessionContextMgtListener.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLInboundSessionContextMgtListener.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.listener.SessionContextMgtListener;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -63,7 +64,12 @@ public class SAMLInboundSessionContextMgtListener implements SessionContextMgtLi
             if (log.isDebugEnabled()) {
                 log.debug("samlssoTokenId not present in the request. Hence creating new value.");
             }
-            sessionId = UUIDGenerator.generateUUID();
+            if (IdentityTenantUtil.isTenantedSessionsEnabled()) {
+                // Add suffix to the session id for identify saml sso token id cookies which has a tenanted path.
+                sessionId = UUIDGenerator.generateUUID() + SAMLSSOConstants.TENANT_QUALIFIED_TOKEN_ID_COOKIE_SUFFIX;
+            } else {
+                sessionId = UUIDGenerator.generateUUID();
+            }
         }
         Map<String, String> map = new HashMap<>();
         map.put(SAML_SSO_TOKEN_ID_COOKIE, sessionId);

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -93,6 +93,7 @@ public class SAMLSSOConstants {
     public static final String INBOUND_AUTH_TYPE_SAML = "samlsso";
     public static final String SAML_SSO_TOKEN_ID_COOKIE = "samlssoTokenId";
     public static final String INBOUND_ISSUER_QUALIFIER = "spQualifier";
+    public static final String TENANT_QUALIFIED_TOKEN_ID_COOKIE_SUFFIX = "-v2";
 
     // SAML2 Artifact Binding
     public static final byte[] SAML2_ARTIFACT_TYPE_CODE = { 0, 4 };

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOSessionDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOSessionDTO.java
@@ -55,6 +55,7 @@ public class SAMLSSOSessionDTO implements Serializable {
     private String requestedAuthnContextComparison;
     private List<ClaimMapping> requestedAttributes;
     private Properties properties;
+    private String loginTenantDomain;
 
     public String getHttpQueryString() {
         return httpQueryString;
@@ -358,5 +359,25 @@ public class SAMLSSOSessionDTO implements Serializable {
     public void setIssuerQualifier(String issuerQualifier) {
 
         this.issuerQualifier = issuerQualifier;
+    }
+
+    /**
+     * Get login tenant domain.
+     *
+     * @return loginTenantDomain login tenant domain.
+     */
+    public String getLoginTenantDomain() {
+
+        return loginTenantDomain;
+    }
+
+    /**
+     * Set login tenant domain.
+     *
+     * @param loginTenantDomain login tenant domain.
+     */
+    public void setLoginTenantDomain(String loginTenantDomain) {
+
+        this.loginTenantDomain = loginTenantDomain;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Enable tenanted paths for the samlssoTokenId cookie if the Tenanted Sessions were enabled. 

### Approach

#### Used following approach to retrieve the login tenant domain.

- Extract the tenant domain from the 't parameter' of the request. (Same as in the common oauth cookie). 
- If there is no 't parameter' in the request, retrieve the tenant domain from the context.

#### Used following approach to avoid the conflicts that can be raised when migrating this fix.

- If the tenanted sessions enabled, added a suffix to to the sessionId (which is used as the samlssoTokenId cookie value).
- So if a user has a active session, at the time of migration happened, we can identify the old samlssoTokenId cookie which has root path using this suffix of the cookie value. 
- So until that old session was terminated, we can manage this old samlssoTokenId cookie, in the root path using this suffix.
- Finally at the end of this old session we can remove that old samlssoTokenId cookie also from the root path.
- This approach is  needed to avoid the issues that can be raised due to two samlssoTokenId cookies.