### PR TITLE
Move identity-inbound-auth-saml caches to the tenant space.

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -103,14 +103,14 @@ public class SAMLSSOService {
      * If the user already having a SSO session then the Response
      * will be returned if not only the validation results will be returned.
      *
-     * @param samlReq
-     * @param queryString
-     * @param sessionId
-     * @param rpSessionId
-     * @param authnMode
-     * @param isPost
-     * @param loginTenantDomain
-     * @return
+     * @param samlReq             SAML Request
+     * @param queryString         Query String
+     * @param sessionId           Session ID
+     * @param rpSessionId         rpSession Id
+     * @param authnMode           Authn Mode
+     * @param isPost              Is Post
+     * @param loginTenantDomain   Login tenant domain
+     * @return    validationResp
      * @throws IdentityException
      */
     public SAMLSSOReqValidationResponseDTO validateSPInitSSORequest(String samlReq, String queryString,
@@ -189,16 +189,16 @@ public class SAMLSSOService {
      * If the user already having a SSO session then the Response
      * will be returned if not only the validation results will be returned.
      *
-     * @param relayState
-     * @param queryString
-     * @param queryParamDTOs
-     * @param serverURL
-     * @param sessionId
-     * @param rpSessionId
-     * @param authnMode
-     * @param isLogout
-     * @param loginTenantDomain
-     * @return
+     * @param relayState            Relay State
+     * @param queryString           Query String
+     * @param queryParamDTOs        Query Param DTOs
+     * @param serverURL             Server url
+     * @param sessionId             Session id
+     * @param rpSessionId           Rp Session id
+     * @param authnMode             Authn Mode
+     * @param isLogout              Is Logout
+     * @param loginTenantDomain     Login tenant Domain
+     * @return      validationResponseDTO
      * @throws IdentityException
      */
     public SAMLSSOReqValidationResponseDTO validateIdPInitSSORequest(String relayState, String queryString,

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -299,8 +299,8 @@ public class SAMLSSOService {
     /**
      * Gets all the session participants from session ID send logout requests to them.
      *
-     * @param sessionId     Session Id.
-     * @param issuer    Issuer.
+     * @param sessionId             Session Id.
+     * @param issuer                Name of the issuer.
      * @param loginTenantDomain     Login Tenant Domain.
      * @throws IdentityException
      */

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/CacheKey.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/CacheKey.java
@@ -18,13 +18,11 @@
 
 package org.wso2.carbon.identity.sso.saml.cache;
 
-import java.io.Serializable;
-
 /**
  * Cache key class. Any value that acts as a cache key must encapsulated with a class
  * overriding from this class.
  */
-public abstract class CacheKey implements Serializable {
+public abstract class CacheKey extends org.wso2.carbon.identity.core.cache.CacheEntry {
 
     private static final long serialVersionUID = -7965616737373453027L;
 

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/SAMLSSOParticipantCache.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/SAMLSSOParticipantCache.java
@@ -58,9 +58,9 @@ public class SAMLSSOParticipantCache extends BaseCache<SAMLSSOParticipantCacheKe
     /**
      * Adds Session Information to the cache and session data store.
      *
-     * @param key   Key which cache entry is indexed.
-     * @param entry Actual object where cache entry is placed.
-     * @param loginTenantDomain Login Tenant Domain where cache will add.
+     * @param key                Key which cache entry is indexed.
+     * @param entry              SAMLSSOParticipant Cache Entry.
+     * @param loginTenantDomain  Login Tenant Domain where cache will add.
      */
     @Override
     public void addToCache(SAMLSSOParticipantCacheKey key, SAMLSSOParticipantCacheEntry entry,
@@ -86,8 +86,8 @@ public class SAMLSSOParticipantCache extends BaseCache<SAMLSSOParticipantCacheKe
      * Retrieve the session information from the cache.
      * At a cache miss data is loaded from the Session DataStore Store
      *
-     * @param key SAMLSSOParticipantCacheKey Key which cache entry is indexed.
-     * @param loginTenantDomain Login Tenant Domain
+     * @param key                SAMLSSOParticipantCacheKey Key which cache entry is indexed.
+     * @param loginTenantDomain  Login Tenant Domain.
      * @return Cache entry
      */
     @Override
@@ -116,8 +116,8 @@ public class SAMLSSOParticipantCache extends BaseCache<SAMLSSOParticipantCacheKe
     /**
      * Clears the Session Information from the cache and remove from session data store.
      *
-     * @param key Key to clear cache.
-     * @param loginTenantDomain Login Tenant Domain where cache was added.
+     * @param key                 Key to clear cache.
+     * @param loginTenantDomain   Login Tenant Domain where cache was added.
      */
     @Override
     public void clearCacheEntry(SAMLSSOParticipantCacheKey key, String loginTenantDomain) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/SAMLSSOParticipantCache.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/SAMLSSOParticipantCache.java
@@ -18,8 +18,10 @@
 
 package org.wso2.carbon.identity.sso.saml.cache;
 
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.authentication.framework.store.SessionDataStore;
-import org.wso2.carbon.identity.application.common.cache.BaseCache;
+import org.wso2.carbon.identity.core.cache.BaseCache;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
 public class SAMLSSOParticipantCache extends BaseCache<SAMLSSOParticipantCacheKey, SAMLSSOParticipantCacheEntry> {
 
@@ -33,6 +35,7 @@ public class SAMLSSOParticipantCache extends BaseCache<SAMLSSOParticipantCacheKe
     public static SAMLSSOParticipantCache getInstance() {
         if (instance == null) {
             synchronized (SAMLSSOParticipantCache.class) {
+
                 if (instance == null) {
                     instance = new SAMLSSOParticipantCache();
                 }
@@ -41,13 +44,57 @@ public class SAMLSSOParticipantCache extends BaseCache<SAMLSSOParticipantCacheKe
         return instance;
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #addToCache(SAMLSSOParticipantCacheKey, SAMLSSOParticipantCacheEntry, String))} instead.
+     */
+    @Deprecated
     public void addToCache(SAMLSSOParticipantCacheKey key, SAMLSSOParticipantCacheEntry entry) {
-        super.addToCache(key, entry);
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        addToCache(key, entry, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Adds Session Information to the cache and session data store.
+     *
+     * @param key   Key which cache entry is indexed.
+     * @param entry Actual object where cache entry is placed.
+     * @param loginTenantDomain Login Tenant Domain where cache will add.
+     */
+    @Override
+    public void addToCache(SAMLSSOParticipantCacheKey key, SAMLSSOParticipantCacheEntry entry,
+                           String loginTenantDomain) {
+
+        String tenantDomain = resolveCacheTenantDomain(loginTenantDomain);
+        super.addToCache(key, entry, tenantDomain);
         SessionDataStore.getInstance().storeSessionData(key.getSessionIndex(), CACHE_NAME, entry);
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #getValueFromCache(SAMLSSOParticipantCacheKey, String))} instead.
+     */
+    @Deprecated
     public SAMLSSOParticipantCacheEntry getValueFromCache(SAMLSSOParticipantCacheKey key) {
-        SAMLSSOParticipantCacheEntry cacheEntry = super.getValueFromCache(key);
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return getValueFromCache(key, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Retrieve the session information from the cache.
+     * At a cache miss data is loaded from the Session DataStore Store
+     *
+     * @param key SAMLSSOParticipantCacheKey Key which cache entry is indexed.
+     * @param loginTenantDomain Login Tenant Domain
+     * @return Cache entry
+     */
+    @Override
+    public SAMLSSOParticipantCacheEntry getValueFromCache(SAMLSSOParticipantCacheKey key, String loginTenantDomain) {
+
+        String tenantDomain = resolveCacheTenantDomain(loginTenantDomain);
+        SAMLSSOParticipantCacheEntry cacheEntry = super.getValueFromCache(key, tenantDomain);
         if (cacheEntry == null) {
             cacheEntry = (SAMLSSOParticipantCacheEntry) SessionDataStore.getInstance().
                     getSessionData(key.getSessionIndex(), CACHE_NAME);
@@ -55,9 +102,44 @@ public class SAMLSSOParticipantCache extends BaseCache<SAMLSSOParticipantCacheKe
         return cacheEntry;
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #clearCacheEntry(SAMLSSOParticipantCacheKey, String))} instead.
+     */
+    @Deprecated
     public void clearCacheEntry(SAMLSSOParticipantCacheKey key) {
-        super.clearCacheEntry(key);
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        clearCacheEntry(key, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Clears the Session Information from the cache and remove from session data store.
+     *
+     * @param key Key to clear cache.
+     * @param loginTenantDomain Login Tenant Domain where cache was added.
+     */
+    @Override
+    public void clearCacheEntry(SAMLSSOParticipantCacheKey key, String loginTenantDomain) {
+
+        String tenantDomain = resolveCacheTenantDomain(loginTenantDomain);
+        super.clearCacheEntry(key, tenantDomain);
         SessionDataStore.getInstance().clearSessionData(key.getSessionIndex(), CACHE_NAME);
+    }
+
+    /**
+     * Return the tenant domain where the cache needed to be maintain.
+     *
+     * @param tenantDomain login tenant domain.
+     * @return tenantDomain Tenant Domain where the cache needed to be maintain.
+     */
+    private String resolveCacheTenantDomain(String tenantDomain) {
+
+        // If tenanted sessions are not enabled, maintain caches in the super tenant domain.
+        if (!IdentityTenantUtil.isTenantedSessionsEnabled()) {
+            return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+        return tenantDomain;
     }
 
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/SAMLSSOSessionIndexCache.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/SAMLSSOSessionIndexCache.java
@@ -18,8 +18,10 @@
 
 package org.wso2.carbon.identity.sso.saml.cache;
 
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.authentication.framework.store.SessionDataStore;
-import org.wso2.carbon.identity.application.common.cache.BaseCache;
+import org.wso2.carbon.identity.core.cache.BaseCache;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
 public class SAMLSSOSessionIndexCache extends BaseCache<SAMLSSOSessionIndexCacheKey, SAMLSSOSessionIndexCacheEntry> {
 
@@ -41,13 +43,57 @@ public class SAMLSSOSessionIndexCache extends BaseCache<SAMLSSOSessionIndexCache
         return instance;
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOSessionIndexCache to the tenant space.
+     * Use {@link #addToCache(SAMLSSOSessionIndexCacheKey, SAMLSSOSessionIndexCacheEntry, String))} instead.
+     */
+    @Deprecated
     public void addToCache(SAMLSSOSessionIndexCacheKey key, SAMLSSOSessionIndexCacheEntry entry) {
-        super.addToCache(key, entry);
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        addToCache(key, entry, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Adds Session Index to the cache and session data store.
+     *
+     * @param key   Key which cache entry is indexed.
+     * @param entry Actual object where cache entry is placed.
+     * @param loginTenantDomain Login Tenant Domain where cache will add.
+     */
+    @Override
+    public void addToCache(SAMLSSOSessionIndexCacheKey key, SAMLSSOSessionIndexCacheEntry entry,
+                           String loginTenantDomain) {
+
+        String tenantDomain = resolveCacheTenantDomain(loginTenantDomain);
+        super.addToCache(key, entry, tenantDomain);
         SessionDataStore.getInstance().storeSessionData(key.getTokenId(), CACHE_NAME, entry);
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOSessionIndexCache to the tenant space.
+     * Use {@link #getValueFromCache(SAMLSSOSessionIndexCacheKey, String))} instead.
+     */
+    @Deprecated
     public SAMLSSOSessionIndexCacheEntry getValueFromCache(SAMLSSOSessionIndexCacheKey key) {
-        SAMLSSOSessionIndexCacheEntry cacheEntry = super.getValueFromCache(key);
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return getValueFromCache(key, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Retrieve the session Index from the cache.
+     * At a cache miss data is loaded from the Session Data Store.
+     *
+     * @param key SAMLSSOSessionIndexCacheKey Key which cache entry is indexed.
+     * @param loginTenantDomain Login Tenant Domain
+     * @return Cache entry
+     */
+    @Override
+    public SAMLSSOSessionIndexCacheEntry getValueFromCache(SAMLSSOSessionIndexCacheKey key, String loginTenantDomain) {
+
+        String tenantDomain = resolveCacheTenantDomain(loginTenantDomain);
+        SAMLSSOSessionIndexCacheEntry cacheEntry = super.getValueFromCache(key, tenantDomain);
         if (cacheEntry == null) {
             cacheEntry = (SAMLSSOSessionIndexCacheEntry) SessionDataStore.getInstance().getSessionData(key.getTokenId(),
                     CACHE_NAME);
@@ -55,8 +101,43 @@ public class SAMLSSOSessionIndexCache extends BaseCache<SAMLSSOSessionIndexCache
         return cacheEntry;
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOSessionIndexCache to the tenant space.
+     * Use {@link #clearCacheEntry(SAMLSSOSessionIndexCacheKey, String))} instead.
+     */
+    @Deprecated
     public void clearCacheEntry(SAMLSSOSessionIndexCacheKey key) {
-        super.clearCacheEntry(key);
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        clearCacheEntry(key, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Clears the Session Index from the cache and remove from session data store.
+     *
+     * @param key Key to clear cache.
+     * @param loginTenantDomain Login Tenant Domain where cache was added.
+     */
+    @Override
+    public void clearCacheEntry(SAMLSSOSessionIndexCacheKey key, String loginTenantDomain) {
+
+        String tenantDomain = resolveCacheTenantDomain(loginTenantDomain);
+        super.clearCacheEntry(key, tenantDomain);
         SessionDataStore.getInstance().clearSessionData(key.getTokenId(), CACHE_NAME);
+    }
+
+    /**
+     * Return the tenant domain where the cache needed to be maintain.
+     *
+     * @param tenantDomain login tenant domain.
+     * @return tenantDomain Tenant Domain where the cache needed to be maintain.
+     */
+    private String resolveCacheTenantDomain(String tenantDomain) {
+
+        // If tenanted sessions are not enabled, maintain caches in the super tenant domain.
+        if (!IdentityTenantUtil.isTenantedSessionsEnabled()) {
+            return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+        return tenantDomain;
     }
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/SAMLSSOSessionIndexCache.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/SAMLSSOSessionIndexCache.java
@@ -57,8 +57,8 @@ public class SAMLSSOSessionIndexCache extends BaseCache<SAMLSSOSessionIndexCache
     /**
      * Adds Session Index to the cache and session data store.
      *
-     * @param key   Key which cache entry is indexed.
-     * @param entry Actual object where cache entry is placed.
+     * @param key               Key which cache entry is indexed.
+     * @param entry             SAMLSSOSessionIndex Cache Entry.
      * @param loginTenantDomain Login Tenant Domain where cache will add.
      */
     @Override
@@ -85,8 +85,8 @@ public class SAMLSSOSessionIndexCache extends BaseCache<SAMLSSOSessionIndexCache
      * Retrieve the session Index from the cache.
      * At a cache miss data is loaded from the Session Data Store.
      *
-     * @param key SAMLSSOSessionIndexCacheKey Key which cache entry is indexed.
-     * @param loginTenantDomain Login Tenant Domain
+     * @param key                SAMLSSOSessionIndexCacheKey Key which cache entry is indexed.
+     * @param loginTenantDomain  Login Tenant Domain.
      * @return Cache entry
      */
     @Override
@@ -115,8 +115,8 @@ public class SAMLSSOSessionIndexCache extends BaseCache<SAMLSSOSessionIndexCache
     /**
      * Clears the Session Index from the cache and remove from session data store.
      *
-     * @param key Key to clear cache.
-     * @param loginTenantDomain Login Tenant Domain where cache was added.
+     * @param key                   Key to clear cache.
+     * @param loginTenantDomain     Login Tenant Domain where cache was added.
      */
     @Override
     public void clearCacheEntry(SAMLSSOSessionIndexCacheKey key, String loginTenantDomain) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOAuthnReqDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOAuthnReqDTO.java
@@ -86,6 +86,7 @@ public class SAMLSSOAuthnReqDTO implements Serializable {
     private boolean doValidateSignatureInArtifactResolve;
     private boolean samlECPEnabled;
     private long createdTimeStamp;
+    private String loginTenantDomain;
 
     public void setDoValidateSignatureInArtifactResolve(boolean doValidateSignatureInArtifactResolve) {
 
@@ -717,5 +718,25 @@ public class SAMLSSOAuthnReqDTO implements Serializable {
     public void setIssuerQualifier(String issuerQualifier) {
 
         this.issuerQualifier = issuerQualifier;
+    }
+
+    /**
+     * Get login tenant domain.
+     *
+     * @return loginTenantDomain login tenant domain.
+     */
+    public String getLoginTenantDomain() {
+
+        return loginTenantDomain;
+    }
+
+    /**
+     * Set login tenant domain.
+     *
+     * @param loginTenantDomain login tenant domain.
+     */
+    public void setLoginTenantDomain(String loginTenantDomain) {
+
+        this.loginTenantDomain = loginTenantDomain;
     }
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitLogoutRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitLogoutRequestProcessor.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.sso.saml.session.SSOSessionPersistenceManager;
 import org.wso2.carbon.identity.sso.saml.session.SessionInfoData;
 import org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtil;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.Map;
 
@@ -41,8 +42,30 @@ public class IdPInitLogoutRequestProcessor implements IdpInitSSOLogoutRequestPro
     private String spEntityID;
     private String returnTo;
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #process(String, QueryParamDTO[], String, String)} )} instead.
+     */
+    @Deprecated
     public SAMLSSOReqValidationResponseDTO process(String sessionId, QueryParamDTO[] queryParamDTOs,
                                                    String serverURL) throws IdentityException {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return process(sessionId, queryParamDTOs, serverURL, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+    }
+
+    /**
+     *
+     * @param sessionId
+     * @param queryParamDTOs
+     * @param serverURL
+     * @param loginTenantDomain
+     * @return
+     * @throws IdentityException
+     */
+    public SAMLSSOReqValidationResponseDTO process(String sessionId, QueryParamDTO[] queryParamDTOs, String serverURL,
+                                                   String loginTenantDomain) throws IdentityException {
 
         init(queryParamDTOs);
 
@@ -61,8 +84,9 @@ public class IdPInitLogoutRequestProcessor implements IdpInitSSOLogoutRequestPro
 
             SSOSessionPersistenceManager ssoSessionPersistenceManager = SSOSessionPersistenceManager
                     .getPersistenceManager();
-            String sessionIndex = ssoSessionPersistenceManager.getSessionIndexFromTokenId(sessionId);
-            SessionInfoData sessionInfoData = ssoSessionPersistenceManager.getSessionInfo(sessionIndex);
+            String sessionIndex = ssoSessionPersistenceManager.getSessionIndexFromTokenId(sessionId, loginTenantDomain);
+            SessionInfoData sessionInfoData = ssoSessionPersistenceManager.
+                    getSessionInfo(sessionIndex, loginTenantDomain);
 
             if (sessionInfoData == null) {
                 log.error(SAMLSSOConstants.Notification.INVALID_SESSION);

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitLogoutRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitLogoutRequestProcessor.java
@@ -56,12 +56,13 @@ public class IdPInitLogoutRequestProcessor implements IdpInitSSOLogoutRequestPro
     }
 
     /**
+     * Process IDP initiated Logout Request.
      *
-     * @param sessionId
-     * @param queryParamDTOs
-     * @param serverURL
-     * @param loginTenantDomain
-     * @return
+     * @param sessionId             Session Id.
+     * @param queryParamDTOs        Query Param DTOs.
+     * @param serverURL             Server url.
+     * @param loginTenantDomain     Login tenant Domain.
+     * @return  validationResponseDTO.
      * @throws IdentityException
      */
     public SAMLSSOReqValidationResponseDTO process(String sessionId, QueryParamDTO[] queryParamDTOs, String serverURL,

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitSSOAuthnRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitSSOAuthnRequestProcessor.java
@@ -113,11 +113,14 @@ public class IdPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor
             String sessionIndexId = null;
 
             if (isAuthenticated) {
-                if (sessionId != null && sessionPersistenceManager.isExistingTokenId(sessionId)) {
-                    sessionIndexId = sessionPersistenceManager.getSessionIndexFromTokenId(sessionId);
+                if (sessionId != null && sessionPersistenceManager.isExistingTokenId(sessionId,
+                        authnReqDTO.getLoginTenantDomain())) {
+                    sessionIndexId = sessionPersistenceManager.getSessionIndexFromTokenId(sessionId,
+                            authnReqDTO.getLoginTenantDomain());
                 } else {
                     sessionIndexId = UUIDGenerator.generateUUID();
-                    sessionPersistenceManager.persistSession(sessionId, sessionIndexId);
+                    sessionPersistenceManager.persistSession(sessionId, sessionIndexId,
+                            authnReqDTO.getLoginTenantDomain());
                 }
 
                 if (authMode.equals(SAMLSSOConstants.AuthnModes.USERNAME_PASSWORD)) {
@@ -144,7 +147,8 @@ public class IdPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor
                     sessionPersistenceManager.persistSession(sessionIndexId,
                             authnReqDTO.getUser().getAuthenticatedSubjectIdentifier(), spDO,
                             authnReqDTO.getRpSessionId(), authnReqDTO.getIssuer(),
-                            authnReqDTO.getAssertionConsumerURL());
+                            authnReqDTO.getAssertionConsumerURL(),
+                            authnReqDTO.getLoginTenantDomain());
                 }
 
                 // Build the response for the successful scenario

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
@@ -79,10 +79,12 @@ public class SPInitLogoutRequestProcessor implements SPInitSSOLogoutRequestProce
     }
 
     /**
-     * @param logoutRequest
-     * @param sessionId
-     * @param queryString
-     * @param loginTenantDomain
+     * Process SP initiated Logout Request.
+     *
+     * @param logoutRequest     Logout Request
+     * @param sessionId         Session Id
+     * @param queryString       Query String
+     * @param loginTenantDomain Login tenant domain
      * @return SAMLSSOReqValidationResponseDTO
      * @throws IdentityException
      */

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.sso.saml.validators.ValidationResult;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -65,9 +66,28 @@ public class SPInitLogoutRequestProcessor implements SPInitSSOLogoutRequestProce
      * @param queryString
      * @return
      * @throws IdentityException
+     *
+     * @deprecated This method was deprecated to move saml caches to the tenant space.
+     * Use {@link #process(LogoutRequest, String, String, String)}  instead.
      */
+    @Deprecated
     public SAMLSSOReqValidationResponseDTO process(LogoutRequest logoutRequest, String sessionId,
                                                    String queryString) throws IdentityException {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return process(logoutRequest, sessionId, queryString, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * @param logoutRequest
+     * @param sessionId
+     * @param queryString
+     * @param loginTenantDomain
+     * @return SAMLSSOReqValidationResponseDTO
+     * @throws IdentityException
+     */
+    public SAMLSSOReqValidationResponseDTO process(LogoutRequest logoutRequest, String sessionId, String queryString,
+                                                   String loginTenantDomain) throws IdentityException {
 
         SAMLSSOReqValidationResponseDTO reqValidationResponseDTO = new SAMLSSOReqValidationResponseDTO();
         reqValidationResponseDTO.setLogOutReq(true);
@@ -98,7 +118,7 @@ public class SPInitLogoutRequestProcessor implements SPInitSSOLogoutRequestProce
 
             // Validate whether we have principle session.
             ValidationResult<SAMLSSOReqValidationResponseDTO> validationResult =
-                    validatePrincipleSession(sessionId, logoutRequest);
+                    validatePrincipleSession(sessionId, logoutRequest, loginTenantDomain);
             if (!validationResult.getValidationStatus()) {
                 return validationResult.getValue();
             }
@@ -108,14 +128,15 @@ public class SPInitLogoutRequestProcessor implements SPInitSSOLogoutRequestProce
             // Get the sessions from the SessionPersistenceManager and prepare the logout responses.
             SSOSessionPersistenceManager ssoSessionPersistenceManager = SSOSessionPersistenceManager
                     .getPersistenceManager();
-            String sessionIndex = getSessionIndex(sessionId, logoutRequest);
+            String sessionIndex = getSessionIndex(sessionId, logoutRequest, loginTenantDomain);
             /* 'SessionIndex' attribute can be optional in the SAML logout request. In that case we need to retrieve
             the session index from session Id. */
             if (sessionIndex == null) {
                 sessionIndex = SSOSessionPersistenceManager.getPersistenceManager().getSessionIndexFromTokenId
-                        (sessionId);
+                        (sessionId, loginTenantDomain);
             }
-            SessionInfoData sessionInfoData = ssoSessionPersistenceManager.getSessionInfo(sessionIndex);
+            SessionInfoData sessionInfoData = ssoSessionPersistenceManager.
+                    getSessionInfo(sessionIndex, loginTenantDomain);
             issuer = getTenantAwareIssuer(issuer, sessionInfoData);
 
             // Replace SP's issuer value with the actual issuer value in SAML SP registry.
@@ -351,7 +372,8 @@ public class SPInitLogoutRequestProcessor implements SPInitSSOLogoutRequestProce
     }
 
     private ValidationResult<SAMLSSOReqValidationResponseDTO> validatePrincipleSession(String sessionId,
-                                                                                       LogoutRequest logoutRequest)
+                                                                                       LogoutRequest logoutRequest,
+                                                                                       String loginTenantDomain)
             throws IOException, IdentityException {
 
         String issuer = logoutRequest.getIssuer().getValue();
@@ -370,7 +392,7 @@ public class SPInitLogoutRequestProcessor implements SPInitSSOLogoutRequestProce
             return validationResult;
         }
 
-        String sessionIndex = getSessionIndex(sessionId, logoutRequest);
+        String sessionIndex = getSessionIndex(sessionId, logoutRequest, loginTenantDomain);
 
         if (StringUtils.isBlank(sessionIndex)) {
             String message = "Error while retrieving the Session Index ";
@@ -385,7 +407,7 @@ public class SPInitLogoutRequestProcessor implements SPInitSSOLogoutRequestProce
 
         SSOSessionPersistenceManager ssoSessionPersistenceManager =
                 SSOSessionPersistenceManager.getPersistenceManager();
-        SessionInfoData sessionInfoData = ssoSessionPersistenceManager.getSessionInfo(sessionIndex);
+        SessionInfoData sessionInfoData = ssoSessionPersistenceManager.getSessionInfo(sessionIndex, loginTenantDomain);
 
         if (sessionInfoData == null) {
             String message = "No Established Sessions corresponding to Session Indexes provided.";
@@ -460,13 +482,13 @@ public class SPInitLogoutRequestProcessor implements SPInitSSOLogoutRequestProce
         }
     }
 
-    private String getSessionIndex(String sessionId, LogoutRequest logoutRequest) {
+    private String getSessionIndex(String sessionId, LogoutRequest logoutRequest, String loginTenantDomain) {
 
         SSOSessionPersistenceManager ssoSessionPersistenceManager =
                 SSOSessionPersistenceManager.getPersistenceManager();
         if (!logoutRequest.getSessionIndexes().isEmpty()) {
             return logoutRequest.getSessionIndexes().get(0).getSessionIndex();
         }
-        return ssoSessionPersistenceManager.getSessionIndexFromTokenId(sessionId);
+        return ssoSessionPersistenceManager.getSessionIndexFromTokenId(sessionId, loginTenantDomain);
     }
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
@@ -99,11 +99,14 @@ public class SPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor{
             String sessionIndexId = null;
 
             if (isAuthenticated) {
-                if (sessionId != null && sessionPersistenceManager.isExistingTokenId(sessionId)) {
-                    sessionIndexId = sessionPersistenceManager.getSessionIndexFromTokenId(sessionId);
+                if (sessionId != null && sessionPersistenceManager.
+                        isExistingTokenId(sessionId, authnReqDTO.getLoginTenantDomain())) {
+                    sessionIndexId = sessionPersistenceManager.getSessionIndexFromTokenId(sessionId,
+                            authnReqDTO.getLoginTenantDomain());
                 } else {
                     sessionIndexId = UUIDGenerator.generateUUID();
-                    sessionPersistenceManager.persistSession(sessionId, sessionIndexId);
+                    sessionPersistenceManager.persistSession(sessionId, sessionIndexId,
+                            authnReqDTO.getLoginTenantDomain());
                 }
 
                 //TODO check whether the same SP exists
@@ -135,7 +138,8 @@ public class SPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor{
                             authnReqDTO.getUser().getAuthenticatedSubjectIdentifier(),
                             spDO, authnReqDTO.getRpSessionId(),
                             authnReqDTO.getIssuer(),
-                            authnReqDTO.getAssertionConsumerURL());
+                            authnReqDTO.getAssertionConsumerURL(),
+                            authnReqDTO.getLoginTenantDomain());
                 }
 
                 // Build the response for the successful scenario

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/session/SSOSessionPersistenceManager.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/session/SSOSessionPersistenceManager.java
@@ -90,8 +90,8 @@ public class SSOSessionPersistenceManager {
     /**
      * Adds Session Index to the cache.
      *
-     * @param key           Key which cache entry is indexed
-     * @param sessionIndex  Session Index.
+     * @param key                   Key which cache entry is indexed
+     * @param sessionIndex          Session Index.
      * @param loginTenantDomain     Tenant Domain where cache will add.
      */
     public static void addSessionIndexToCache(String key, String sessionIndex, String loginTenantDomain) {
@@ -116,8 +116,8 @@ public class SSOSessionPersistenceManager {
     /**
      * Retrieve the session information from the cache.
      *
-     * @param key String.
-     * @param loginTenantDomain Login Tenant Domain
+     * @param key                Cache key
+     * @param loginTenantDomain  Login Tenant Domain
      * @return SessionInfoData
      */
     public static SessionInfoData getSessionInfoDataFromCache(String key, String loginTenantDomain) {
@@ -148,8 +148,8 @@ public class SSOSessionPersistenceManager {
     /**
      * Retrieve the session index from the cache.
      *
-     * @param key String.
-     * @param loginTenantDomain String.
+     * @param key                Cache Key.
+     * @param loginTenantDomain  Login Tenant Domain.
      * @return session index.
      */
     public static String getSessionIndexFromCache(String key, String loginTenantDomain) {
@@ -180,7 +180,7 @@ public class SSOSessionPersistenceManager {
     /**
      * Clears the Session Information from the cache.
      *
-     * @param key   Cache Key.
+     * @param key                   Cache Key.
      * @param loginTenantDomain     Login Tenant Domain.
      */
     public static void removeSessionInfoDataFromCache(String key, String loginTenantDomain) {
@@ -205,7 +205,7 @@ public class SSOSessionPersistenceManager {
     /**
      * Clears the session index from cache.
      *
-     * @param key   Cache Key.
+     * @param key                   Cache Key.
      * @param loginTenantDomain     Login Tenant Domain.
      */
     public static void removeSessionIndexFromCache(String key, String loginTenantDomain) {
@@ -233,13 +233,13 @@ public class SSOSessionPersistenceManager {
     /**
      * Persists Session Information.
      *
-     * @param sessionIndex String .
-     * @param subject String.
-     * @param spDO SAMLSSOServiceProviderDO.
-     * @param rpSessionId String.
-     * @param issuer String.
-     * @param assertionConsumerURL String.
-     * @param loginTenantDomain String.
+     * @param sessionIndex          Session Index
+     * @param subject               Subject
+     * @param spDO                  SAMLSSOServiceProviderDO
+     * @param rpSessionId           Rp Session id
+     * @param issuer                Name of the issuer
+     * @param assertionConsumerURL  Assertion Consumer URL
+     * @param loginTenantDomain     Login Tenant Domain
      */
     public void persistSession(String sessionIndex, String subject, SAMLSSOServiceProviderDO spDO,
                                String rpSessionId, String issuer, String assertionConsumerURL, String loginTenantDomain)
@@ -280,7 +280,7 @@ public class SSOSessionPersistenceManager {
     /**
      * Get the session info data for a particular session.
      *
-     * @param sessionIndex      Session Index.
+     * @param sessionIndex          Session Index.
      * @param loginTenantDomain     Login Tenant Domain.
      * @return SessionInfoData
      */
@@ -317,7 +317,7 @@ public class SSOSessionPersistenceManager {
     /**
      * Check whether this is an existing session.
      *
-     * @param sessionIndex      Session Index.
+     * @param sessionIndex          Session Index.
      * @param loginTenantDomain     Login Tenant Domain.
      * @return true if this is an existing session, or else return false
      */
@@ -375,7 +375,7 @@ public class SSOSessionPersistenceManager {
     /**
      * Checks the token id is an existing one.
      *
-     * @param tokenId   Token Id.
+     * @param tokenId               Token Id.
      * @param loginTenantDomain     Login Tenant Domain.
      * @return true if token id is a existing one.
      */
@@ -408,9 +408,9 @@ public class SSOSessionPersistenceManager {
     /**
      * Clear the session when logout is called.
      *
-     * @param sessionId created session id to invalidate
-     * @param issuer name of the issuer
-     * @param loginTenantDomain tenant domain where the cache is maintaining
+     * @param sessionId         created session id to invalidate
+     * @param issuer            name of the issuer
+     * @param loginTenantDomain login tenant domain
      */
     public static void removeSession(String sessionId, String issuer, String loginTenantDomain) {
 
@@ -491,7 +491,7 @@ public class SSOSessionPersistenceManager {
     /**
      * Get the session index from cache.
      *
-     * @param tokenId Token Id.
+     * @param tokenId           Token Id.
      * @param loginTenantDomain Login tenant Domain.
      * @return  Session Index.
      */
@@ -512,9 +512,9 @@ public class SSOSessionPersistenceManager {
     }
 
     /**
-     *Clears the session index from cache.
+     * Clears the session index from cache.
      *
-     * @param sessionId     Session Id.
+     * @param sessionId             Session Id.
      * @param loginTenantDomain     Login Tenant Domain.
      */
     public void removeTokenId(String sessionId, String loginTenantDomain) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/session/SSOSessionPersistenceManager.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/session/SSOSessionPersistenceManager.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.sso.saml.session;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.SAMLSSOServiceProviderDO;
 import org.wso2.carbon.identity.sso.saml.cache.SAMLSSOParticipantCache;
@@ -48,27 +49,83 @@ public class SSOSessionPersistenceManager {
         return sessionPersistenceManager;
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #addSessionInfoDataToCache(String, SessionInfoData, String))} instead.
+     */
+    @Deprecated
     public static void addSessionInfoDataToCache(String key, SessionInfoData sessionInfoData) {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        addSessionInfoDataToCache(key, sessionInfoData, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Adds Session Information to the cache.
+     *
+     * @param key                    Key which cache entry is indexed.
+     * @param sessionInfoData        Session Information Data.
+     * @param loginTenantDomain      Tenant Domain where cache will add.
+     */
+    public static void addSessionInfoDataToCache(String key, SessionInfoData sessionInfoData,
+                                                 String loginTenantDomain) {
 
         SAMLSSOParticipantCacheKey cacheKey = new SAMLSSOParticipantCacheKey(key);
         SAMLSSOParticipantCacheEntry cacheEntry = new SAMLSSOParticipantCacheEntry();
         cacheEntry.setSessionInfoData(sessionInfoData);
-        SAMLSSOParticipantCache.getInstance().addToCache(cacheKey, cacheEntry);
+        SAMLSSOParticipantCache.getInstance().addToCache(cacheKey, cacheEntry, loginTenantDomain);
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOSessionIndexCache to the tenant space.
+     * Use {@link #addSessionIndexToCache(String, String, String))} instead.
+     */
+    @Deprecated
     public static void addSessionIndexToCache(String key, String sessionIndex) {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        addSessionIndexToCache(key, sessionIndex, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Adds Session Index to the cache.
+     *
+     * @param key           Key which cache entry is indexed
+     * @param sessionIndex  Session Index.
+     * @param loginTenantDomain     Tenant Domain where cache will add.
+     */
+    public static void addSessionIndexToCache(String key, String sessionIndex, String loginTenantDomain) {
 
         SAMLSSOSessionIndexCacheKey cacheKey = new SAMLSSOSessionIndexCacheKey(key);
         SAMLSSOSessionIndexCacheEntry cacheEntry = new SAMLSSOSessionIndexCacheEntry();
         cacheEntry.setSessionIndex(sessionIndex);
-        SAMLSSOSessionIndexCache.getInstance().addToCache(cacheKey, cacheEntry);
+        SAMLSSOSessionIndexCache.getInstance().addToCache(cacheKey, cacheEntry, loginTenantDomain);
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #getSessionInfoDataFromCache(String, String))} instead.
+     */
+    @Deprecated
     public static SessionInfoData getSessionInfoDataFromCache(String key) {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return getSessionInfoDataFromCache(key, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Retrieve the session information from the cache.
+     *
+     * @param key String.
+     * @param loginTenantDomain Login Tenant Domain
+     * @return SessionInfoData
+     */
+    public static SessionInfoData getSessionInfoDataFromCache(String key, String loginTenantDomain) {
 
         SessionInfoData sessionInfoData = null;
         SAMLSSOParticipantCacheKey cacheKey = new SAMLSSOParticipantCacheKey(key);
-        SAMLSSOParticipantCacheEntry cacheEntry = SAMLSSOParticipantCache.getInstance().getValueFromCache(cacheKey);
+        SAMLSSOParticipantCacheEntry cacheEntry = SAMLSSOParticipantCache.getInstance().
+                getValueFromCache(cacheKey, loginTenantDomain);
 
         if (cacheEntry != null) {
             sessionInfoData = cacheEntry.getSessionInfoData();
@@ -77,11 +134,30 @@ public class SSOSessionPersistenceManager {
         return sessionInfoData;
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOSessionIndexCache to the tenant space.
+     * Use {@link #getSessionIndexFromCache(String, String))} instead.
+     */
+    @Deprecated
     public static String getSessionIndexFromCache(String key) {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return getSessionIndexFromCache(key, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Retrieve the session index from the cache.
+     *
+     * @param key String.
+     * @param loginTenantDomain String.
+     * @return session index.
+     */
+    public static String getSessionIndexFromCache(String key, String loginTenantDomain) {
 
         String sessionIndex = null;
         SAMLSSOSessionIndexCacheKey cacheKey = new SAMLSSOSessionIndexCacheKey(key);
-        SAMLSSOSessionIndexCacheEntry cacheEntry = SAMLSSOSessionIndexCache.getInstance().getValueFromCache(cacheKey);
+        SAMLSSOSessionIndexCacheEntry cacheEntry = SAMLSSOSessionIndexCache.getInstance().
+                getValueFromCache(cacheKey, loginTenantDomain);
 
         if (cacheEntry != null) {
             sessionIndex = cacheEntry.getSessionIndex();
@@ -90,27 +166,86 @@ public class SSOSessionPersistenceManager {
         return sessionIndex;
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #removeSessionInfoDataFromCache(String, String))} instead.
+     */
+    @Deprecated
     public static void removeSessionInfoDataFromCache(String key) {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        removeSessionInfoDataFromCache(key, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Clears the Session Information from the cache.
+     *
+     * @param key   Cache Key.
+     * @param loginTenantDomain     Login Tenant Domain.
+     */
+    public static void removeSessionInfoDataFromCache(String key, String loginTenantDomain) {
 
         if (key != null) {
             SAMLSSOParticipantCacheKey cacheKey = new SAMLSSOParticipantCacheKey(key);
-            SAMLSSOParticipantCache.getInstance().clearCacheEntry(cacheKey);
+            SAMLSSOParticipantCache.getInstance().clearCacheEntry(cacheKey, loginTenantDomain);
         }
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOSessionIndexCache to the tenant space.
+     * Use {@link #removeSessionIndexFromCache(String, String))} instead.
+     */
+    @Deprecated
     public static void removeSessionIndexFromCache(String key) {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        removeSessionIndexFromCache(key, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Clears the session index from cache.
+     *
+     * @param key   Cache Key.
+     * @param loginTenantDomain     Login Tenant Domain.
+     */
+    public static void removeSessionIndexFromCache(String key, String loginTenantDomain) {
 
         if (key != null) {
             SAMLSSOSessionIndexCacheKey cacheKey = new SAMLSSOSessionIndexCacheKey(key);
-            SAMLSSOSessionIndexCache.getInstance().clearCacheEntry(cacheKey);
+            SAMLSSOSessionIndexCache.getInstance().clearCacheEntry(cacheKey, loginTenantDomain);
         }
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #persistSession(String, String, SAMLSSOServiceProviderDO, String, String, String, String))} instead.
+     */
+    @Deprecated
     public void persistSession(String sessionIndex, String subject, SAMLSSOServiceProviderDO spDO,
                                String rpSessionId, String issuer, String assertionConsumerURL)
             throws IdentityException {
 
-        SessionInfoData sessionInfoData = getSessionInfoDataFromCache(sessionIndex);
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        persistSession(sessionIndex, subject, spDO, rpSessionId, issuer, assertionConsumerURL,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Persists Session Information.
+     *
+     * @param sessionIndex String .
+     * @param subject String.
+     * @param spDO SAMLSSOServiceProviderDO.
+     * @param rpSessionId String.
+     * @param issuer String.
+     * @param assertionConsumerURL String.
+     * @param loginTenantDomain String.
+     */
+    public void persistSession(String sessionIndex, String subject, SAMLSSOServiceProviderDO spDO,
+                               String rpSessionId, String issuer, String assertionConsumerURL, String loginTenantDomain)
+            throws IdentityException {
+
+        SessionInfoData sessionInfoData = getSessionInfoDataFromCache(sessionIndex, loginTenantDomain);
 
         if (sessionInfoData == null) {
             sessionInfoData = new SessionInfoData();
@@ -122,7 +257,7 @@ public class SSOSessionPersistenceManager {
         }
         sessionInfoData.setSubject(issuer, subject);
         sessionInfoData.addServiceProvider(spDO.getIssuer(), spDO, rpSessionId);
-        addSessionInfoDataToCache(sessionIndex, sessionInfoData);
+        addSessionInfoDataToCache(sessionIndex, sessionInfoData, loginTenantDomain);
 
     }
 
@@ -131,9 +266,27 @@ public class SSOSessionPersistenceManager {
      *
      * @param sessionIndex
      * @return
+     *
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #getSessionInfo(String, String))} instead.
      */
+    @Deprecated
     public SessionInfoData getSessionInfo(String sessionIndex) {
-        return getSessionInfoDataFromCache(sessionIndex);
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return getSessionInfo(sessionIndex, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Get the session info data for a particular session.
+     *
+     * @param sessionIndex      Session Index.
+     * @param loginTenantDomain     Login Tenant Domain.
+     * @return SessionInfoData
+     */
+    public SessionInfoData getSessionInfo(String sessionIndex, String loginTenantDomain) {
+
+        return getSessionInfoDataFromCache(sessionIndex, loginTenantDomain);
     }
 
     /**
@@ -141,6 +294,7 @@ public class SSOSessionPersistenceManager {
      *
      * @param sessionIndex
      */
+    @Deprecated
     public void removeSession(String sessionIndex) {
         removeSessionInfoDataFromCache(sessionIndex);
     }
@@ -149,16 +303,52 @@ public class SSOSessionPersistenceManager {
      * Check whether this is an existing session
      *
      * @return
+     *
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #isExistingSession(String, String))} instead.
      */
+    @Deprecated
     public boolean isExistingSession(String sessionIndex) {
-        SessionInfoData sessionInfoData = getSessionInfoDataFromCache(sessionIndex);
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return isExistingSession(sessionIndex, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Check whether this is an existing session.
+     *
+     * @param sessionIndex      Session Index.
+     * @param loginTenantDomain     Login Tenant Domain.
+     * @return true if this is an existing session, or else return false
+     */
+    public boolean isExistingSession(String sessionIndex, String loginTenantDomain) {
+
+        SessionInfoData sessionInfoData = getSessionInfoDataFromCache(sessionIndex, loginTenantDomain);
         if (sessionInfoData != null) {
             return true;
         }
         return false;
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOSessionIndexCache to the tenant space.
+     * Use {@link #persistSession(String, String, String))} instead.
+     */
+    @Deprecated
     public void persistSession(String tokenId, String sessionIndex) {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        persistSession(tokenId, sessionIndex, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Adds Session Index to the cache.
+     *
+     * @param tokenId               Token Id.
+     * @param sessionIndex          Session Index.
+     * @param loginTenantDomain     Login Tenant Domain.
+     */
+    public void persistSession(String tokenId, String sessionIndex, String loginTenantDomain) {
         if (tokenId == null) {
             log.debug("SSO Token Id is null.");
             return;
@@ -167,13 +357,31 @@ public class SSOSessionPersistenceManager {
             log.debug("SessionIndex is null.");
             return;
         }
-        addSessionIndexToCache(tokenId, sessionIndex);
+        addSessionIndexToCache(tokenId, sessionIndex, loginTenantDomain);
 
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOSessionIndexCache to the tenant space.
+     * Use {@link #isExistingTokenId(String, String))} instead.
+     */
+    @Deprecated
     public boolean isExistingTokenId(String tokenId) {
 
-        String sessionIndex = getSessionIndexFromCache(tokenId);
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return isExistingTokenId (tokenId, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Checks the token id is an existing one.
+     *
+     * @param tokenId   Token Id.
+     * @param loginTenantDomain     Login Tenant Domain.
+     * @return true if token id is a existing one.
+     */
+    public boolean isExistingTokenId(String tokenId, String loginTenantDomain) {
+
+        String sessionIndex = getSessionIndexFromCache(tokenId, loginTenantDomain);
 
         if (sessionIndex != null) {
             return true;
@@ -186,12 +394,29 @@ public class SSOSessionPersistenceManager {
      *
      * @param sessionId created session id to invalidate
      * @param issuer name of the issuer
+     *
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #removeSession(String, String, String)} )} instead.
      */
+    @Deprecated
     public static void removeSession(String sessionId, String issuer) {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        removeSession (sessionId, issuer, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Clear the session when logout is called.
+     *
+     * @param sessionId created session id to invalidate
+     * @param issuer name of the issuer
+     * @param loginTenantDomain tenant domain where the cache is maintaining
+     */
+    public static void removeSession(String sessionId, String issuer, String loginTenantDomain) {
 
         String sessionIndex = null;
         if (sessionId != null) {
-            sessionIndex = getSessionIndexFromCache(sessionId);
+            sessionIndex = getSessionIndexFromCache(sessionId, loginTenantDomain);
             if(log.isDebugEnabled()) {
                 log.debug("Retrieved session index from session id with session index " + sessionIndex);
             }
@@ -199,7 +424,8 @@ public class SSOSessionPersistenceManager {
 
         if (sessionIndex != null) {
             SAMLSSOParticipantCacheKey cacheKey = new SAMLSSOParticipantCacheKey(sessionIndex);
-            SAMLSSOParticipantCacheEntry cacheEntry = SAMLSSOParticipantCache.getInstance().getValueFromCache(cacheKey);
+            SAMLSSOParticipantCacheEntry cacheEntry = SAMLSSOParticipantCache.getInstance().
+                    getValueFromCache(cacheKey, loginTenantDomain);
             if (issuer != null) {
                 if (cacheEntry.getSessionInfoData() != null && cacheEntry.getSessionInfoData().getServiceProviderList() != null) {
                     SAMLSSOServiceProviderDO providerDO = cacheEntry.getSessionInfoData().getServiceProviderList().get(issuer);
@@ -225,8 +451,8 @@ public class SSOSessionPersistenceManager {
                 if(log.isDebugEnabled()) {
                     log.debug("Clearing the session data from cache with session index " + sessionIndex + " and issuer " + issuer);
                 }
-                SAMLSSOParticipantCache.getInstance().clearCacheEntry(cacheKey);
-                removeSessionIndexFromCache(sessionId);
+                SAMLSSOParticipantCache.getInstance().clearCacheEntry(cacheKey, loginTenantDomain);
+                removeSessionIndexFromCache(sessionId, loginTenantDomain);
             }
         }
     }
@@ -251,11 +477,48 @@ public class SSOSessionPersistenceManager {
         }
     }
 
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOSessionIndexCache to the tenant space.
+     * Use {@link #getSessionIndexFromTokenId(String, String))} instead.
+     */
+    @Deprecated
     public String getSessionIndexFromTokenId(String tokenId) {
-        return getSessionIndexFromCache(tokenId);
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return getSessionIndexFromTokenId(tokenId, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
     }
 
+    /**
+     * Get the session index from cache.
+     *
+     * @param tokenId Token Id.
+     * @param loginTenantDomain Login tenant Domain.
+     * @return  Session Index.
+     */
+    public String getSessionIndexFromTokenId(String tokenId, String loginTenantDomain) {
+
+        return getSessionIndexFromCache(tokenId, loginTenantDomain);
+    }
+
+    /**
+     * @deprecated This method was deprecated to move SAMLSSOSessionIndexCache to the tenant space.
+     * Use {@link #removeTokenId(String, String))} instead.
+     */
+    @Deprecated
     public void removeTokenId(String sessionId) {
-        removeSessionIndexFromCache(sessionId);
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        removeTokenId(sessionId, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     *Clears the session index from cache.
+     *
+     * @param sessionId     Session Id.
+     * @param loginTenantDomain     Login Tenant Domain.
+     */
+    public void removeTokenId(String sessionId, String loginTenantDomain) {
+
+        removeSessionIndexFromCache(sessionId, loginTenantDomain);
     }
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -2249,10 +2249,10 @@ public class SAMLSSOUtil {
     /**
      * Get remaining session participants for SLO except for the original issuer.
      *
-     * @param sessionIndex Session index.
-     * @param issuer       Original issuer.
-     * @param isIdPInitSLO Whether IdP initiated SLO or not.
-     * @param loginTenantDomain  Login Tenant Domain
+     * @param sessionIndex          Session index.
+     * @param issuer                Original issuer.
+     * @param isIdPInitSLO          Whether IdP initiated SLO or not.
+     * @param loginTenantDomain     Login Tenant Domain
      * @return SP List with remaining session participants for SLO except for the original issuer.
      *
      */
@@ -2311,8 +2311,8 @@ public class SAMLSSOUtil {
     /**
      * Get SessionInfoData.
      *
-     * @param sessionIndex Session index.
-     * @param loginTenantDomain Tenant Domain.
+     * @param sessionIndex       Session index.
+     * @param loginTenantDomain  Login Tenant Domain.
      * @return Session Info Data.
      */
     public static SessionInfoData getSessionInfoData(String sessionIndex, String loginTenantDomain) {
@@ -2343,7 +2343,7 @@ public class SAMLSSOUtil {
     /**
      * Get Session Index.
      *
-     * @param sessionId Session id.
+     * @param sessionId         Session id.
      * @param loginTenantDomain Login Tenant Domain.
      * @return Session Index.
      */

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -1629,10 +1629,11 @@ public class SAMLSSOUtil {
     }
 
     /**
+     *  Removes the session.
      *
-     * @param sessionId
-     * @param issuer
-     * @param loginTenantDomain
+     * @param sessionId          Session id.
+     * @param issuer             Issuer.
+     * @param loginTenantDomain  Login tenant Domain.
      */
     public static void removeSession(String sessionId, String issuer, String loginTenantDomain) {
 

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -1618,10 +1618,27 @@ public class SAMLSSOUtil {
         return normalized.toString();
     }
 
+    /**
+     * @deprecated This method was deprecated to move saml caches to the tenant space.
+     * Use {@link #removeSession(String, String, String)}  )} instead.
+     */
+    @Deprecated
     public static void removeSession(String sessionId, String issuer) {
+
+        removeSession(sessionId, issuer, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     *
+     * @param sessionId
+     * @param issuer
+     * @param loginTenantDomain
+     */
+    public static void removeSession(String sessionId, String issuer, String loginTenantDomain) {
+
         SSOSessionPersistenceManager ssoSessionPersistenceManager = SSOSessionPersistenceManager
                 .getPersistenceManager();
-        ssoSessionPersistenceManager.removeSession(sessionId, issuer);
+        ssoSessionPersistenceManager.removeSession(sessionId, issuer, loginTenantDomain);
     }
 
     public static void setTenantDomainInThreadLocal(String tenantDomain) throws UserStoreException, IdentityException {
@@ -2215,9 +2232,31 @@ public class SAMLSSOUtil {
      * @param issuer       Original issuer.
      * @param isIdPInitSLO Whether IdP initiated SLO or not.
      * @return SP List with remaining session participants for SLO except for the original issuer.
+     *
+     * @deprecated This method was deprecated to move saml caches to the tenant space.
+     * Use {@link #getRemainingSessionParticipantsForSLO(String, String, boolean, String)}  instead.
      */
+    @Deprecated
     public static List<SAMLSSOServiceProviderDO> getRemainingSessionParticipantsForSLO(
             String sessionIndex, String issuer, boolean isIdPInitSLO) {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return getRemainingSessionParticipantsForSLO(sessionIndex, issuer, isIdPInitSLO,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Get remaining session participants for SLO except for the original issuer.
+     *
+     * @param sessionIndex Session index.
+     * @param issuer       Original issuer.
+     * @param isIdPInitSLO Whether IdP initiated SLO or not.
+     * @param loginTenantDomain  Login Tenant Domain
+     * @return SP List with remaining session participants for SLO except for the original issuer.
+     *
+     */
+    public static List<SAMLSSOServiceProviderDO> getRemainingSessionParticipantsForSLO(
+            String sessionIndex, String issuer, boolean isIdPInitSLO, String loginTenantDomain) {
 
         if (isIdPInitSLO) {
             issuer = null;
@@ -2225,7 +2264,7 @@ public class SAMLSSOUtil {
 
         SSOSessionPersistenceManager ssoSessionPersistenceManager = SSOSessionPersistenceManager
                 .getPersistenceManager();
-        SessionInfoData sessionInfoData = ssoSessionPersistenceManager.getSessionInfo(sessionIndex);
+        SessionInfoData sessionInfoData = ssoSessionPersistenceManager.getSessionInfo(sessionIndex, loginTenantDomain);
 
         List<SAMLSSOServiceProviderDO> samlssoServiceProviderDOList;
 
@@ -2257,12 +2296,29 @@ public class SAMLSSOUtil {
      *
      * @param sessionIndex Session index.
      * @return Session Info Data.
+     *
+     * @deprecated This method was deprecated to move SAMLSSOParticipantCache to the tenant space.
+     * Use {@link #getSessionInfoData(String, String)}  instead.
      */
+    @Deprecated
     public static SessionInfoData getSessionInfoData(String sessionIndex) {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return getSessionInfoData(sessionIndex, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Get SessionInfoData.
+     *
+     * @param sessionIndex Session index.
+     * @param loginTenantDomain Tenant Domain.
+     * @return Session Info Data.
+     */
+    public static SessionInfoData getSessionInfoData(String sessionIndex, String loginTenantDomain) {
 
         SSOSessionPersistenceManager ssoSessionPersistenceManager = SSOSessionPersistenceManager
                 .getPersistenceManager();
-        SessionInfoData sessionInfoData = ssoSessionPersistenceManager.getSessionInfo(sessionIndex);
+        SessionInfoData sessionInfoData = ssoSessionPersistenceManager.getSessionInfo(sessionIndex, loginTenantDomain);
 
         return sessionInfoData;
     }
@@ -2272,12 +2328,29 @@ public class SAMLSSOUtil {
      *
      * @param sessionId Session id.
      * @return Session Index.
+     *
+     * @deprecated This method was deprecated to move SAMLSSOSessionIndexCache to the tenant space.
+     * Use {@link #getSessionIndex(String, String)}  instead.
      */
+    @Deprecated
     public static String getSessionIndex(String sessionId) {
+
+        // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
+        return getSessionIndex(sessionId, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * Get Session Index.
+     *
+     * @param sessionId Session id.
+     * @param loginTenantDomain Login Tenant Domain.
+     * @return Session Index.
+     */
+    public static String getSessionIndex(String sessionId, String loginTenantDomain) {
 
         SSOSessionPersistenceManager ssoSessionPersistenceManager = SSOSessionPersistenceManager
                 .getPersistenceManager();
-        String sessionIndex = ssoSessionPersistenceManager.getSessionIndexFromTokenId(sessionId);
+        String sessionIndex = ssoSessionPersistenceManager.getSessionIndexFromTokenId(sessionId, loginTenantDomain);
 
         return sessionIndex;
     }

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAMLLogoutHandlerTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAMLLogoutHandlerTest.java
@@ -107,6 +107,12 @@ public class SAMLLogoutHandlerTest extends PowerMockTestCase {
     public void setUp() throws Exception {
 
         TestUtils.startTenantFlow(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantId(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)).
+                thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(IdentityTenantUtil.getTenantDomain(MultitenantConstants.SUPER_TENANT_ID)).
+                thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
         SAMLSSOServiceProviderDO serviceProviderDOOne = new SAMLSSOServiceProviderDO();
         serviceProviderDOOne.setIssuer("issuerOne");
         serviceProviderDOOne.setDoSingleLogout(true);
@@ -122,10 +128,14 @@ public class SAMLLogoutHandlerTest extends PowerMockTestCase {
         sessionInfoDataTwo.addServiceProvider("issuerOne", serviceProviderDOOne, null);
         sessionInfoDataTwo.addServiceProvider("issuerTwo", serviceProviderDOTwo, null);
 
-        SSOSessionPersistenceManager.addSessionIndexToCache(SESSION_TOKEN_ID_ONE, SESSION_INDEX_ONE);
-        SSOSessionPersistenceManager.addSessionIndexToCache(SESSION_TOKEN_ID_TWO, SESSION_INDEX_TWO);
-        SSOSessionPersistenceManager.addSessionInfoDataToCache(SESSION_INDEX_ONE, sessionInfoDataOne);
-        SSOSessionPersistenceManager.addSessionInfoDataToCache(SESSION_INDEX_TWO, sessionInfoDataTwo);
+        SSOSessionPersistenceManager.addSessionIndexToCache(SESSION_TOKEN_ID_ONE, SESSION_INDEX_ONE,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        SSOSessionPersistenceManager.addSessionIndexToCache(SESSION_TOKEN_ID_TWO, SESSION_INDEX_TWO,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        SSOSessionPersistenceManager.addSessionInfoDataToCache(SESSION_INDEX_ONE, sessionInfoDataOne,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        SSOSessionPersistenceManager.addSessionInfoDataToCache(SESSION_INDEX_TWO, sessionInfoDataTwo,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
         // creating mocks
         createMocks();
@@ -176,10 +186,11 @@ public class SAMLLogoutHandlerTest extends PowerMockTestCase {
     public void testHandleEvent() throws Exception {
 
         Event eventOne = setupEvent(IdentityEventConstants.EventName.SESSION_TERMINATE.name(), "issuerOne");
-        mockStatic(IdentityTenantUtil.class);
         samlLogoutHandler.handleEvent(eventOne);
-        SessionInfoData sessionInfoDataOne = SSOSessionPersistenceManager.getSessionInfoDataFromCache(SESSION_INDEX_ONE);
-        SessionInfoData sessionInfoDataTwo = SSOSessionPersistenceManager.getSessionInfoDataFromCache(SESSION_INDEX_TWO);
+        SessionInfoData sessionInfoDataOne = SSOSessionPersistenceManager.getSessionInfoDataFromCache(SESSION_INDEX_ONE,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        SessionInfoData sessionInfoDataTwo = SSOSessionPersistenceManager.getSessionInfoDataFromCache(SESSION_INDEX_TWO,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertNull(sessionInfoDataOne);
         Assert.assertNotNull(sessionInfoDataTwo);
     }

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAMLSSOServiceTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAMLSSOServiceTest.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.sso.saml.processors.IdPInitSSOAuthnRequestProces
 import org.wso2.carbon.identity.sso.saml.processors.SPInitSSOAuthnRequestProcessor;
 import org.wso2.carbon.identity.sso.saml.session.SSOSessionPersistenceManager;
 import org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -139,7 +140,8 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
 
         SAMLSSOService samlssoService = new SAMLSSOService();
         SAMLSSOReqValidationResponseDTO samlssoReqValidationResponseDTO = samlssoService.validateSPInitSSORequest(
-                encodedAuthnRequest, queryString, null, null, TestConstants.BASIC_AUTHN_MODE, isPost);
+                encodedAuthnRequest, queryString, null, null, TestConstants.BASIC_AUTHN_MODE, isPost,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertTrue(samlssoReqValidationResponseDTO.isValid(), "Should be a valid SAML authentication request.");
         assertFalse(samlssoReqValidationResponseDTO.isIdPInitSSO(), "Should not be an IDP initiated SAML SSO request.");
         assertEquals(samlssoReqValidationResponseDTO.getQueryString(), queryString, "Query String should be same as " +
@@ -155,7 +157,7 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
         SAMLSSOUtil.doBootstrap();
 
         SPInitLogoutRequestProcessor spInitLogoutRequestProcessor = mock(SPInitLogoutRequestProcessor.class);
-        when(spInitLogoutRequestProcessor.process(any(LogoutRequest.class), anyString(), anyString())).thenReturn(
+        when(spInitLogoutRequestProcessor.process(any(LogoutRequest.class), anyString(), anyString(), anyString())).thenReturn(
                 mockValidSPInitLogoutRequestProcessing(TestConstants.ACS_URL));
         mockStatic(SAMLSSOUtil.class);
         when(SAMLSSOUtil.getSPInitLogoutRequestProcessor()).thenReturn(spInitLogoutRequestProcessor);
@@ -165,7 +167,8 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
 
         SAMLSSOService samlssoService = new SAMLSSOService();
         SAMLSSOReqValidationResponseDTO samlssoReqValidationResponseDTO = samlssoService.validateSPInitSSORequest(
-                encodedLogoutRequest, queryString, "sessionId", null, TestConstants.BASIC_AUTHN_MODE, isPost);
+                encodedLogoutRequest, queryString, "sessionId", null, TestConstants.BASIC_AUTHN_MODE,
+                isPost, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertNotNull(samlssoReqValidationResponseDTO, "Validation response of SP-init SLO request should not be " +
                 "null.");
     }
@@ -205,7 +208,8 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
 
         SAMLSSOService samlssoService = new SAMLSSOService();
         SAMLSSOReqValidationResponseDTO samlssoReqValidationResponseDTO = samlssoService.validateIdPInitSSORequest(
-                relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId, authnMode, isLogout);
+                relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId, authnMode, isLogout,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertTrue(samlssoReqValidationResponseDTO.isValid(), "Should be a valid SAML authentication request.");
         assertTrue(samlssoReqValidationResponseDTO.isIdPInitSSO(), "Should be an IDP initiated SAML SSO request.");
         assertEquals(samlssoReqValidationResponseDTO.getQueryString(), queryString, "Query String should be same as " +
@@ -233,14 +237,15 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
         boolean isLogout = true;
 
         IdPInitLogoutRequestProcessor idPInitLogoutRequestProcessor = mock(IdPInitLogoutRequestProcessor.class);
-        when(idPInitLogoutRequestProcessor.process(anyString(), any(QueryParamDTO[].class), anyString()))
+        when(idPInitLogoutRequestProcessor.process(anyString(), any(QueryParamDTO[].class), anyString(), anyString()))
                 .thenReturn(mockValidIDPInitLogoutRequestProcessing(queryParamDTOs[2].getValue()));
         mockStatic(SAMLSSOUtil.class);
         when(SAMLSSOUtil.getIdPInitLogoutRequestProcessor()).thenReturn(idPInitLogoutRequestProcessor);
 
         SAMLSSOService samlssoService = new SAMLSSOService();
         SAMLSSOReqValidationResponseDTO samlssoReqValidationResponseDTO = samlssoService.validateIdPInitSSORequest(
-                relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId, authnMode, isLogout);
+                relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId, authnMode, isLogout,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertTrue(samlssoReqValidationResponseDTO.isValid(), "Should be a valid SAML SLO request.");
         assertTrue(samlssoReqValidationResponseDTO.isIdPInitSLO(), "Should be an IDP initiated SLO request");
         assertEquals(samlssoReqValidationResponseDTO.getQueryString(), queryString, "Query String should be same as " +
@@ -321,7 +326,7 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
         SSOSessionPersistenceManager ssoSessionPersistenceManager = mock(SSOSessionPersistenceManager.class);
         mockStatic(SSOSessionPersistenceManager.class);
         when(SSOSessionPersistenceManager.getPersistenceManager()).thenReturn(ssoSessionPersistenceManager);
-        when(ssoSessionPersistenceManager.getSessionIndexFromTokenId(anyString())).thenReturn("theSessionIndex");
+        when(ssoSessionPersistenceManager.getSessionIndexFromTokenId(anyString(), anyString())).thenReturn("theSessionIndex");
 
         SAMLSSOService samlssoService = new SAMLSSOService();
         assertTrue(samlssoService.doSingleLogout("aSeesionID").isLogOutReq(), " Should return" +

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/session/SSOSessionPersistenceManagerTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/session/SSOSessionPersistenceManagerTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.sso.saml.session;
 
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -26,6 +27,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.SAMLSSOServiceProviderDO;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.sso.saml.TestConstants;
 import org.wso2.carbon.identity.sso.saml.TestUtils;
 import org.wso2.carbon.identity.sso.saml.cache.SAMLSSOParticipantCache;
@@ -38,7 +40,10 @@ import org.wso2.carbon.identity.sso.saml.common.SAMLSSOProviderConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 
+@PrepareForTest({IdentityTenantUtil.class})
 public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
 
     private SSOSessionPersistenceManager ssoSessionPersistenceManager;
@@ -49,8 +54,14 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
         initMocks(this);
         ssoSessionPersistenceManager = new SSOSessionPersistenceManager();
         TestUtils.startTenantFlow(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantId(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)).
+                thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(IdentityTenantUtil.getTenantDomain(MultitenantConstants.SUPER_TENANT_ID)).
+                thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         //remove the exsisting sessionIndex from cache
-        SSOSessionPersistenceManager.removeSessionIndexFromCache("sessionId");
+        SSOSessionPersistenceManager.removeSessionIndexFromCache("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
     }
 
     @AfterMethod
@@ -72,9 +83,11 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
     public void testAddSessionIndexToCache() throws Exception {
 
         String actualSessionIndex = null;
-        SSOSessionPersistenceManager.addSessionIndexToCache("tokenid", "sessionIndex");
+        SSOSessionPersistenceManager.addSessionIndexToCache("tokenid", "sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SAMLSSOSessionIndexCacheKey cacheKey = new SAMLSSOSessionIndexCacheKey("tokenid");
-        SAMLSSOSessionIndexCacheEntry cacheEntry = SAMLSSOSessionIndexCache.getInstance().getValueFromCache(cacheKey);
+        SAMLSSOSessionIndexCacheEntry cacheEntry = SAMLSSOSessionIndexCache.getInstance().getValueFromCache(cacheKey,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertNotNull(cacheEntry);
         actualSessionIndex = cacheEntry.getSessionIndex();
         Assert.assertEquals(actualSessionIndex, "sessionIndex");
@@ -84,8 +97,10 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
     public void testGetSessionInfoDataFromCache() throws Exception {
 
         SessionInfoData sessionInfoData = new SessionInfoData();
-        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionId", sessionInfoData);
-        SessionInfoData actualSesssionInfoData = SSOSessionPersistenceManager.getSessionInfoDataFromCache("sessionId");
+        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionId", sessionInfoData,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        SessionInfoData actualSesssionInfoData = SSOSessionPersistenceManager.
+                getSessionInfoDataFromCache("sessionId", MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertEquals(actualSesssionInfoData, sessionInfoData);
     }
 
@@ -93,8 +108,10 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
     public void testGetSessionIndexFromCache() throws Exception {
 
         String sessionIndex = "sessionIndex";
-        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", sessionIndex);
-        String actualSessionIndex = SSOSessionPersistenceManager.getSessionIndexFromCache("sessionId");
+        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", sessionIndex,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        String actualSessionIndex = SSOSessionPersistenceManager.getSessionIndexFromCache("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertEquals(actualSessionIndex, sessionIndex);
     }
 
@@ -102,9 +119,11 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
     public void testAddSessionInfoDataToCache() throws Exception {
 
         SessionInfoData sessionInfoData = new SessionInfoData();
-        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionId", sessionInfoData);
+        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionId", sessionInfoData,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SAMLSSOParticipantCacheKey cacheKey = new SAMLSSOParticipantCacheKey("sessionId");
-        SAMLSSOParticipantCacheEntry cacheEntry = SAMLSSOParticipantCache.getInstance().getValueFromCache(cacheKey);
+        SAMLSSOParticipantCacheEntry cacheEntry = SAMLSSOParticipantCache.getInstance().
+                getValueFromCache(cacheKey, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertNotNull(cacheEntry);
         SessionInfoData actualSessionInfoData = cacheEntry.getSessionInfoData();
         Assert.assertEquals(actualSessionInfoData, sessionInfoData);
@@ -113,23 +132,33 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
     @Test
     public void testRemoveSessionInfoDataFromCache() throws Exception {
 
-        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionId", new SessionInfoData());
-        SSOSessionPersistenceManager.removeSessionInfoDataFromCache(null);
-        Assert.assertNotNull(SSOSessionPersistenceManager.getSessionInfoDataFromCache("sessionId"));
-        SSOSessionPersistenceManager.removeSessionInfoDataFromCache("sessionId");
-        Assert.assertNull(SSOSessionPersistenceManager.getSessionInfoDataFromCache("sessionId"));
+        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionId", new SessionInfoData(),
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        SSOSessionPersistenceManager.removeSessionInfoDataFromCache(null,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        Assert.assertNotNull(SSOSessionPersistenceManager.getSessionInfoDataFromCache("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
+        SSOSessionPersistenceManager.removeSessionInfoDataFromCache("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        Assert.assertNull(SSOSessionPersistenceManager.getSessionInfoDataFromCache("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
     }
 
     @Test
     public void testRemoveSessionIndexFromCache() throws Exception {
 
         String sessionIndex;
-        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", "sessionIndex");
-        SSOSessionPersistenceManager.removeSessionIndexFromCache(null);
-        sessionIndex = SSOSessionPersistenceManager.getSessionIndexFromCache("sessionId");
+        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", "sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        SSOSessionPersistenceManager.removeSessionIndexFromCache(null,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        sessionIndex = SSOSessionPersistenceManager.getSessionIndexFromCache("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertNotNull(sessionIndex);
-        SSOSessionPersistenceManager.removeSessionIndexFromCache("sessionId");
-        sessionIndex = SSOSessionPersistenceManager.getSessionIndexFromCache("sessionId");
+        SSOSessionPersistenceManager.removeSessionIndexFromCache("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        sessionIndex = SSOSessionPersistenceManager.getSessionIndexFromCache("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertNull(sessionIndex);
     }
 
@@ -137,17 +166,22 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
     public void testGetSessionIndexFromTokenId() throws Exception {
 
         String sessionIndex = "sessionIndex";
-        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", sessionIndex);
-        String actualSessionIndex = ssoSessionPersistenceManager.getSessionIndexFromTokenId("sessionId");
+        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", sessionIndex,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        String actualSessionIndex = ssoSessionPersistenceManager.getSessionIndexFromTokenId("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertEquals(actualSessionIndex, sessionIndex);
     }
 
     @Test
     public void testRemoveTokenId() throws Exception {
 
-        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", "sessionIndex");
-        ssoSessionPersistenceManager.removeTokenId("sessionId");
-        String sessionIndex = ssoSessionPersistenceManager.getSessionIndexFromTokenId("sessionId");
+        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", "sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        ssoSessionPersistenceManager.removeTokenId("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        String sessionIndex = ssoSessionPersistenceManager.getSessionIndexFromTokenId("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertNull(sessionIndex);
     }
 
@@ -155,27 +189,35 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
     public void testIsExistingTokenId() throws Exception {
 
         String sessionIndex = "sessionIndex";
-        SSOSessionPersistenceManager.addSessionIndexToCache("sessionIndex", sessionIndex);
-        Assert.assertEquals(ssoSessionPersistenceManager.isExistingTokenId("sessionIndex"), true);
-        SSOSessionPersistenceManager.removeSessionIndexFromCache(sessionIndex);
-        Assert.assertEquals(ssoSessionPersistenceManager.isExistingTokenId("sessionIndex"), false);
+        SSOSessionPersistenceManager.addSessionIndexToCache("sessionIndex", sessionIndex,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        Assert.assertEquals(ssoSessionPersistenceManager.isExistingTokenId("sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME), true);
+        SSOSessionPersistenceManager.removeSessionIndexFromCache(sessionIndex,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        Assert.assertEquals(ssoSessionPersistenceManager.isExistingTokenId("sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME), false);
     }
 
     @Test
     public void testGetSessionInfo() throws Exception {
 
         SessionInfoData sessionInfoData = new SessionInfoData();
-        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionIndex", sessionInfoData);
-        SessionInfoData actualSessionInfoData = ssoSessionPersistenceManager.getSessionInfo("sessionIndex");
+        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionIndex", sessionInfoData,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        SessionInfoData actualSessionInfoData = ssoSessionPersistenceManager.getSessionInfo("sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertEquals(actualSessionInfoData, sessionInfoData);
     }
 
     @Test
     public void testRemoveSession() throws Exception {
 
-        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionIndex", new SessionInfoData());
+        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionIndex", new SessionInfoData(),
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         ssoSessionPersistenceManager.removeSession("sessionIndex");
-        SessionInfoData sessionInfoData = SSOSessionPersistenceManager.getSessionInfoDataFromCache("sessionIndex");
+        SessionInfoData sessionInfoData = SSOSessionPersistenceManager.getSessionInfoDataFromCache("sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertNull(sessionInfoData);
     }
 
@@ -183,10 +225,14 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
     public void testIsExistingSession() throws Exception {
 
         SessionInfoData sessionInfoData = new SessionInfoData();
-        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionIndex", sessionInfoData);
-        Assert.assertEquals(ssoSessionPersistenceManager.isExistingSession("sessionIndex"), true);
-        SSOSessionPersistenceManager.removeSessionInfoDataFromCache("sessionIndex");
-        Assert.assertEquals(ssoSessionPersistenceManager.isExistingSession("sessionIndex"), false);
+        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionIndex", sessionInfoData,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        Assert.assertEquals(ssoSessionPersistenceManager.isExistingSession("sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME), true);
+        SSOSessionPersistenceManager.removeSessionInfoDataFromCache("sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        Assert.assertEquals(ssoSessionPersistenceManager.isExistingSession("sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME), false);
     }
 
     @DataProvider(name = "testPersistSession1")
@@ -202,8 +248,10 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
     @Test(dataProvider = "testPersistSession1")
     public void testPersistSession1(String sessionId, String sessionIndex) throws Exception {
 
-        ssoSessionPersistenceManager.persistSession(sessionId, sessionIndex);
-        String actualValue = ssoSessionPersistenceManager.getSessionIndexFromTokenId(sessionId);
+        ssoSessionPersistenceManager.persistSession(sessionId, sessionIndex,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        String actualValue = ssoSessionPersistenceManager.getSessionIndexFromTokenId(sessionId,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Assert.assertEquals(actualValue, sessionIndex);
     }
 
@@ -213,10 +261,12 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
         String issuer = "testUser";
         SAMLSSOServiceProviderDO samlssoServiceProviderDO = new SAMLSSOServiceProviderDO();
         samlssoServiceProviderDO.setIssuer(issuer);
-        SSOSessionPersistenceManager.addSessionInfoDataToCache("samlTokenId", new SessionInfoData());
+        SSOSessionPersistenceManager.addSessionInfoDataToCache("samlTokenId", new SessionInfoData(),
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         ssoSessionPersistenceManager.persistSession("samlTokenId", "subject", samlssoServiceProviderDO,
-                "rpSessionId", issuer, TestConstants.ACS_URL);
-        SessionInfoData sessionInfoData = ssoSessionPersistenceManager.getSessionInfoDataFromCache("samlTokenId");
+                "rpSessionId", issuer, TestConstants.ACS_URL, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        SessionInfoData sessionInfoData = ssoSessionPersistenceManager.getSessionInfoDataFromCache("samlTokenId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
         Assert.assertEquals(sessionInfoData.getSubject(issuer), "subject");
         Assert.assertFalse(sessionInfoData.getRPSessionsList().isEmpty());
@@ -234,32 +284,40 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
         SAMLSSOServiceProviderDO samlssoServiceProviderDO = new SAMLSSOServiceProviderDO();
         samlssoServiceProviderDO.setIssuer(issuer);
         samlssoServiceProviderDO.setDoSingleLogout(true);
-        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", sessionIndex);
+        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", sessionIndex,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SSOSessionPersistenceManager.getPersistenceManager().persistSession(sessionIndex, subject,
-                samlssoServiceProviderDO, null, issuer, null);
+                samlssoServiceProviderDO, null, issuer, null,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
         SAMLSSOServiceProviderDO samlssoServiceProviderDO1 = new SAMLSSOServiceProviderDO();
         samlssoServiceProviderDO1.setIssuer("issuer1");
         samlssoServiceProviderDO1.setDoSingleLogout(true);
-        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId1", "sessionIndex2");
+        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId1", "sessionIndex2",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SSOSessionPersistenceManager.getPersistenceManager().persistSession("sessionIndex2", subject,
-                samlssoServiceProviderDO1, null, "issuer1", null);
+                samlssoServiceProviderDO1, null, "issuer1", null,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
         SAMLSSOServiceProviderDO samlssoServiceProviderDO2 = new SAMLSSOServiceProviderDO();
         samlssoServiceProviderDO2.setIssuer("issuer2");
         samlssoServiceProviderDO2.setDoSingleLogout(false);
-        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId2", sessionIndex);
+        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId2", sessionIndex,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SSOSessionPersistenceManager.getPersistenceManager().persistSession(sessionIndex, subject,
-                samlssoServiceProviderDO2, null, "issuer2", null);
+                samlssoServiceProviderDO2, null, "issuer2", null,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
         SAMLSSOServiceProviderDO samlssoServiceProviderDO3 = new SAMLSSOServiceProviderDO();
         samlssoServiceProviderDO3.setIssuer("issuer3");
         samlssoServiceProviderDO3.setDoSingleLogout(true);
         samlssoServiceProviderDO3.setDoFrontChannelLogout(true);
         samlssoServiceProviderDO3.setFrontChannelLogoutBinding(SAMLSSOProviderConstants.HTTP_REDIRECT_BINDING);
-        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId3", "sessionIndex3");
+        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId3", "sessionIndex3",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SSOSessionPersistenceManager.getPersistenceManager().persistSession("sessionIndex3", subject,
-                samlssoServiceProviderDO3, null, "issuer3", null);
+                samlssoServiceProviderDO3, null, "issuer3", null,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
     }
 
     @DataProvider(name = "testRemoveSession1")
@@ -280,8 +338,9 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
     public void testRemoveSession1(String sessionId, String issuer, String expected) throws Exception {
 
         initializeData();
-        SSOSessionPersistenceManager.removeSession(sessionId, issuer);
-        Assert.assertEquals(SSOSessionPersistenceManager.getSessionIndexFromCache(sessionId), expected);
+        SSOSessionPersistenceManager.removeSession(sessionId, issuer, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        Assert.assertEquals(SSOSessionPersistenceManager.getSessionIndexFromCache(sessionId,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME), expected);
     }
 
     @Test
@@ -290,10 +349,13 @@ public class SSOSessionPersistenceManagerTest extends PowerMockTestCase {
         SAMLSSOServiceProviderDO samlssoServiceProviderDO = new SAMLSSOServiceProviderDO();
         samlssoServiceProviderDO.setIssuer("issuer");
         samlssoServiceProviderDO.setDoSingleLogout(true);
-        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", "sessionIndex");
+        SSOSessionPersistenceManager.addSessionIndexToCache("sessionId", "sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SSOSessionPersistenceManager.getPersistenceManager().persistSession("sessionIndex", "sub",
-                samlssoServiceProviderDO, null, "issuer", null);
-        SSOSessionPersistenceManager.removeSession("sessionId", "issuer");
+                samlssoServiceProviderDO, null, "issuer", null,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        SSOSessionPersistenceManager.removeSession("sessionId", "issuer",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
     }
 
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtilTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtilTest.java
@@ -125,13 +125,17 @@ public class SAMLSSOUtilTest extends PowerMockTestCase {
 
     private void prepareForGetIssuer() throws Exception {
 
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantId(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)).
+                thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(IdentityTenantUtil.getTenantDomain(MultitenantConstants.SUPER_TENANT_ID)).
+                thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         when(tenantManager.getTenantId(anyString())).thenReturn(-1234);
         when(realmService.getTenantManager()).thenReturn(tenantManager);
 
         SAMLSSOUtil.setRealmService(realmService);
 
         prepareResidentIdP();
-        mockStatic(IdentityTenantUtil.class);
     }
 
     private void prepareForGetSPConfig() throws Exception {
@@ -491,8 +495,8 @@ public class SAMLSSOUtilTest extends PowerMockTestCase {
                                                           int expected) {
 
         initializeData();
-        List<SAMLSSOServiceProviderDO> samlssoServiceProviderDOList =
-                SAMLSSOUtil.getRemainingSessionParticipantsForSLO(sessionIndex, issuer, isIdPInitSLO);
+        List<SAMLSSOServiceProviderDO> samlssoServiceProviderDOList = SAMLSSOUtil.getRemainingSessionParticipantsForSLO
+                (sessionIndex, issuer, isIdPInitSLO, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertEquals(samlssoServiceProviderDOList.size(), expected);
 
     }
@@ -512,6 +516,11 @@ public class SAMLSSOUtilTest extends PowerMockTestCase {
     public void initializeData() {
 
         TestUtils.startTenantFlow(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantId(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)).
+                thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(IdentityTenantUtil.getTenantDomain(MultitenantConstants.SUPER_TENANT_ID)).
+                thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         SAMLSSOServiceProviderDO samlssoServiceProviderDO1 = new SAMLSSOServiceProviderDO();
         samlssoServiceProviderDO1.setIssuer("issuer1");
         samlssoServiceProviderDO1.setDoSingleLogout(true);
@@ -529,24 +538,30 @@ public class SAMLSSOUtilTest extends PowerMockTestCase {
         sessionInfoData.addServiceProvider("issuer2", samlssoServiceProviderDO2, null);
         sessionInfoData.addServiceProvider("issuer3", samlssoServiceProviderDO3, null);
 
-        SSOSessionPersistenceManager.addSessionIndexToCache("samlssoTokenId", "sessionIndex");
-        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionIndex", sessionInfoData);
+        SSOSessionPersistenceManager.addSessionIndexToCache("samlssoTokenId", "sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        SSOSessionPersistenceManager.addSessionInfoDataToCache("sessionIndex", sessionInfoData,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
     }
 
     @Test
     public void testGetSessionInfoData() {
 
         initializeData();
-        assertEquals(SAMLSSOUtil.getSessionInfoData("sessionIndex"), sessionInfoData);
-        assertNotEquals(SAMLSSOUtil.getSessionInfoData("sessionIndex1"), sessionInfoData);
+        assertEquals(SAMLSSOUtil.getSessionInfoData("sessionIndex",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME), sessionInfoData);
+        assertNotEquals(SAMLSSOUtil.getSessionInfoData("sessionIndex1",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME), sessionInfoData);
     }
 
     @Test
     public void testGetSessionIndex() {
 
         initializeData();
-        assertEquals(SAMLSSOUtil.getSessionIndex("samlssoTokenId"), "sessionIndex");
-        assertNull(SAMLSSOUtil.getSessionIndex("sessionId"), "Session Index is null.");
+        assertEquals(SAMLSSOUtil.getSessionIndex("samlssoTokenId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME), "sessionIndex");
+        assertNull(SAMLSSOUtil.getSessionIndex("sessionId",
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME), "Session Index is null.");
     }
 
 


### PR DESCRIPTION
### Purpose
Move the following caches to the tenant space.

- SAMLSSOParticipantCache
- SAMLSSOSessionIndexCache

Related Issue : wso2/product-is#11690