### PR TITLE
Add temporary code changes and debug logs for testing purposes

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/SAMLApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/SAMLApplicationMgtListener.java
@@ -82,8 +82,8 @@ public class SAMLApplicationMgtListener extends AbstractApplicationMgtListener {
         if (sp != null) {
             // TODO remove after testing
             if (log.isDebugEnabled()) {
-                log.debug("Service provider associated with the application name: " + applicationName +
-                        " is not null");
+                log.debug("Initiating the deletion of SAML inbound data associated with service provider: "
+                        + applicationName);
             }
             String issuerToBeDeleted = getSAMLIssuer(sp);
             if (StringUtils.isNotBlank(issuerToBeDeleted)) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/SAMLApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/SAMLApplicationMgtListener.java
@@ -80,6 +80,11 @@ public class SAMLApplicationMgtListener extends AbstractApplicationMgtListener {
                 .getApplicationExcludingFileBasedSPs(applicationName, tenantDomain);
 
         if (sp != null) {
+            // TODO remove after testing
+            if (log.isDebugEnabled()) {
+                log.debug("Service provider associated with the application name: " + applicationName +
+                        " is not null");
+            }
             String issuerToBeDeleted = getSAMLIssuer(sp);
             if (StringUtils.isNotBlank(issuerToBeDeleted)) {
                 try {
@@ -88,6 +93,8 @@ public class SAMLApplicationMgtListener extends AbstractApplicationMgtListener {
                                 "service provider: " + applicationName + " of tenantDomain: " + tenantDomain);
                     }
                     SAMLSSOUtil.getSAMLSSOConfigService().removeServiceProvider(issuerToBeDeleted);
+                    // TODO remove after testing
+                    SAMLSSOUtil.getSAMLSSOConfigService().getServiceProvider(issuerToBeDeleted);
                 } catch (IdentityException e) {
                     String msg = "Error removing SAML inbound data for issuer: %s associated with " +
                             "service provider: %s of tenantDomain: %s during application delete.";


### PR DESCRIPTION
Identified an intermittent issue in the SAML service provider deletion flow that only the SP deletion happens and registry related to the SAML inbound data clean is not completed. To test out this issue, added some temporary code changes and debug logs. This will be removed after the testing process.