### PR TITLE
Remove samlssoTokenIdCookie max age value

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -1733,7 +1733,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         if (samlSSOIdCookieConfig.getSameSite() != null) {
             cookie.setSameSite(samlSSOIdCookieConfig.getSameSite());
         }
-        if (age!= null) {
+        if (age != null) {
             cookie.setMaxAge(age);
         }
         cookie.setHttpOnly(samlSSOIdCookieConfig.isHttpOnly());


### PR DESCRIPTION
**Proposed changes in this pull request**

The samlssoTokenIdCookie max age value was preventing the cookie to be cleared on browser close. Setting the max age value was removed at the authentication flow so that the cookie is cleared and a new cookie is created for the next user.

Fixes - [#10934](https://github.com/wso2/product-is/issues/10934)