### PR TITLE
Non-existing SAML SP metadeta URL handle

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/Error.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/Error.java
@@ -23,6 +23,7 @@ public enum Error {
     // Client errors starts with 60, server errors starts with 65.
     INVALID_REQUEST("60001"),
     CONFLICTING_SAML_ISSUER("60002"),
+    URL_NOT_FOUND("60003"),
 
     UNEXPECTED_SERVER_ERROR("65001");
 

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConfigServiceImpl.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConfigServiceImpl.java
@@ -168,7 +168,7 @@ public class SAMLSSOConfigServiceImpl {
             return uploadRPServiceProvider(metadata);
         } catch (IOException e) {
             String tenantDomain = getTenantDomain();
-            throw handleIOException("Non-existing metadata URL for SAML service provider creation in tenantDomain: "
+            throw handleIOException(URL_NOT_FOUND, "Non-existing metadata URL for SAML service provider creation in tenantDomain: "
                     + tenantDomain, e);
         } finally {
             IOUtils.closeQuietly(in);
@@ -211,8 +211,8 @@ public class SAMLSSOConfigServiceImpl {
         return configValue;
     }
 
-    private IdentitySAML2SSOException handleIOException(String message, IOException e) {
-        return new IdentitySAML2ClientException(URL_NOT_FOUND.getErrorCode(), message, e);
+    private IdentitySAML2SSOException handleIOException(Error error, String message, IOException e) {
+        return new IdentitySAML2ClientException(error.getErrorCode(), message, e);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConfigServiceImpl.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConfigServiceImpl.java
@@ -56,6 +56,7 @@ import java.util.function.Predicate;
 
 import static org.wso2.carbon.identity.sso.saml.Error.INVALID_REQUEST;
 import static org.wso2.carbon.identity.sso.saml.Error.UNEXPECTED_SERVER_ERROR;
+import static org.wso2.carbon.identity.sso.saml.Error.URL_NOT_FOUND;
 
 /**
  * Providers an OSGi service layer for SAML service provider configuration management operations.
@@ -167,7 +168,8 @@ public class SAMLSSOConfigServiceImpl {
             return uploadRPServiceProvider(metadata);
         } catch (IOException e) {
             String tenantDomain = getTenantDomain();
-            throw handleIOException("Error while creating SAML service provider in tenantDomain: " + tenantDomain, e);
+            throw handleIOException("Non-existing metadata URL for SAML service provider creation in tenantDomain: "
+                    + tenantDomain, e);
         } finally {
             IOUtils.closeQuietly(in);
         }
@@ -210,7 +212,7 @@ public class SAMLSSOConfigServiceImpl {
     }
 
     private IdentitySAML2SSOException handleIOException(String message, IOException e) {
-        return new IdentitySAML2SSOException(UNEXPECTED_SERVER_ERROR.getErrorCode(), message, e);
+        return new IdentitySAML2ClientException(URL_NOT_FOUND.getErrorCode(), message, e);
     }
 
     /**


### PR DESCRIPTION
Related to https://github.com/wso2-enterprise/asgardeo-product/issues/6505

When the provided metadata URL for SAML application creation is non-existing URL, throw a `IdentitySAML2ClientException` exception.