### PR TITLE
Display App Name in redirection page of SAML Application

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -2175,7 +2175,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                         .getServiceProviderNameByClientId(SAMLSSOUtil.splitAppendedTenantDomain(issuer),
                                 IdentityApplicationConstants.Authenticator.SAML2SSO.NAME, tenantDomain);
             } catch (IdentityApplicationManagementException e) {
-                log.error("Error while getting Service provider name for issuer:" + issuer + " in tenant: " +
+                log.error("Error while getting service provider name for issuer:" + issuer + " in tenant: " +
                         tenantDomain, e);
             }
         }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -1072,7 +1072,6 @@ public class SAMLSSOProviderServlet extends HttpServlet {
             throws IOException {
 
         String finalPage;
-
         String htmlPage = IdentitySAMLSSOServiceComponent.getSsoRedirectHtml();
         String pageWithAcs = htmlPage.replace("$acUrl", acUrl);
         String pageWithApp = pageWithAcs.replace("$app", acUrl);

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -985,7 +985,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
             throw IdentityException.error("Unexpected error in sending message out");
         }
 
-        if (issuer != null && tenantDomain != null && !issuer.isEmpty() && !tenantDomain.isEmpty()){
+        if (StringUtils.isNotBlank(issuer) && StringUtils.isNotBlank(tenantDomain)){
             try {
                 spName = ApplicationManagementService.getInstance()
                         .getServiceProviderNameByClientId(SAMLSSOUtil.splitAppendedTenantDomain(issuer),
@@ -1041,7 +1041,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
 
         PrintWriter out = resp.getWriter();
         String finalPage = "<html><body><p>You are now redirected back to ";
-        if (spName != null && !spName.isEmpty()) {
+        if (StringUtils.isNotBlank(spName)) {
             finalPage = finalPage + Encode.forHtmlContent(spName);
         } else {
             finalPage = finalPage + Encode.forHtmlContent(acUrl);
@@ -1076,7 +1076,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         String pageWithAcs = htmlPage.replace("$acUrl", acUrl);
         String pageWithApp = pageWithAcs.replace("$app", acUrl);
 
-        if (spName != null && !spName.isEmpty()) {
+        if (StringUtils.isNotBlank(spName)) {
             pageWithApp = pageWithAcs.replace("$app", spName);
         }
 
@@ -1966,7 +1966,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         String issuer = SAMLSSOUtil.getIssuerWithQualifierInThreadLocal();
         String tenantDomain = SAMLSSOUtil.getTenantDomainFromThreadLocal();
 
-        if (issuer != null && tenantDomain != null && !issuer.isEmpty() && !tenantDomain.isEmpty()){
+        if (StringUtils.isNotBlank(issuer) && StringUtils.isNotBlank(tenantDomain)){
             try {
                 spName = ApplicationManagementService.getInstance()
                         .getServiceProviderNameByClientId(SAMLSSOUtil.splitAppendedTenantDomain(issuer),

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -1057,10 +1057,10 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         issuer = SAMLSSOUtil.getIssuerWithQualifierInThreadLocal();
         tenantDomain = SAMLSSOUtil.getTenantDomainFromThreadLocal();
         String htmlPage = IdentitySAMLSSOServiceComponent.getSsoRedirectHtml();
-        String pageWithAcs = htmlPage.replace("$acUrl", acUrl);;
-        String pageWithApp = pageWithAcs.replace("$app", acUrl);;
+        String pageWithAcs = htmlPage.replace("$acUrl", acUrl);
+        String pageWithApp = pageWithAcs.replace("$app", acUrl);
 
-        if (!issuer.isEmpty() && !tenantDomain.isEmpty()){
+        if (issuer != null && tenantDomain != null && !issuer.isEmpty() && !tenantDomain.isEmpty()){
             try {
                 String spName = ApplicationManagementService.getInstance()
                         .getServiceProviderNameByClientId(SAMLSSOUtil.splitAppendedTenantDomain(issuer),

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -1944,13 +1944,12 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                 samlssoServiceProviderDO.getDigestAlgorithmUri(), new SignKeyDataHolder(null));
         String encodedRequestMessage = SAMLSSOUtil.encode(SAMLSSOUtil.marshall(logoutRequest));
         String acUrl = logoutRequest.getDestination();
-        printPostPage(response, acUrl, encodedRequestMessage);
+        String spName = resolveAppName();
+        printPostPage(response, acUrl, encodedRequestMessage, spName);
     }
 
-    private void printPostPage(HttpServletResponse response, String acUrl, String encodedRequestMessage)
+    private void printPostPage(HttpServletResponse response, String acUrl, String encodedRequestMessage, String spName)
             throws IOException {
-
-        String spName = resolveAppName();
 
         response.setContentType("text/html; charset=" + StandardCharsets.UTF_8.name());
         if (IdentitySAMLSSOServiceComponent.getSsoRedirectHtml() != null) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -434,7 +434,6 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                                                       FrontChannelSLOParticipantInfo frontChannelSLOParticipantInfo)
             throws IOException, IdentityException, ServletException {
 
-        String tenantDomain = SAMLSSOUtil.getTenantDomainFromThreadLocal();
         if (SSOSessionPersistenceManager.getSessionIndexFromCache(sessionId, getLoggedInTenantDomain(req)) == null) {
             // Remove tokenId Cookie when there is no session available.
             removeTokenIdCookie(req, resp, getLoggedInTenantDomain(req));
@@ -454,7 +453,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
             sendResponse(req, resp, frontChannelSLOParticipantInfo.getRelayState(),
                     SAMLSSOUtil.encode(SAMLSSOUtil.marshall(logoutResponse)),
                     logoutResponse.getDestination(), null, null,
-                    tenantDomain);
+                    SAMLSSOUtil.getTenantDomainFromThreadLocal());
         }
     }
 
@@ -2183,5 +2182,4 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         }
         return null;
     }
-
 }


### PR DESCRIPTION
**Purpose**
 In the authentication flow of the SAML application, the default Assertion consumer URL is getting displayed while redirecting back the user after successful authentication.
 This PR fixes by displaying the app name in the redirection page.
 
