### PR TITLE
Dispaly app name in redirection page

### DIFF
--- a/features/org.wso2.carbon.identity.sso.saml.server.feature/resources/samlsso_response.html
+++ b/features/org.wso2.carbon.identity.sso.saml.server.feature/resources/samlsso_response.html
@@ -208,7 +208,7 @@ Variables $acUrl, $response, $relayState and $additionalParams will be replaced 
                 <p class="padding-bottom-1 text-align-center"><a class="primary-color-btn button" href="javascript:document.getElementById('samlsso-response-form').submit()">Click here</a> if you have been waiting for
                     too long.</p>
 
-                <form id="samlsso-response-form" method="post" action="$acUrl">
+                <form id="samlsso-response-form" method="post" action="$app">
                     <!--$params-->
                     <!--$additionalParams-->
                 </form>


### PR DESCRIPTION
**Purpose**
In the authentication flow of the SAML application, the default Assertion consumer URL is getting displayed while redirecting back the user after successful authentication.
This PR fixes by displaying the app name in the redirection page.