### PR TITLE
Fix saml SSO with spQualifier

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -2484,8 +2484,8 @@ public class SAMLSSOUtil {
             throws IdentityException {
 
         String issuerQualifier = SAMLSSOUtil.getIssuerQualifier();
-        String issuerWithQualifier = null;
-        if (issuerQualifier != null) {
+        String issuerWithQualifier = SAMLSSOUtil.getIssuerWithQualifierInThreadLocal();
+        if (StringUtils.isBlank(issuerWithQualifier) && StringUtils.isNotBlank(issuerQualifier)) {
             issuerWithQualifier = SAMLSSOUtil.getIssuerWithQualifier(issuer, issuerQualifier);
             if (SAMLSSOUtil.isValidSAMLIssuer(issuer, issuerWithQualifier,
                                 SAMLSSOUtil.getTenantDomainFromThreadLocal())) {


### PR DESCRIPTION
Resolves: https://github.com/wso2/product-is/issues/15037

When SAML spQualifier is configured, SAML SSO request is breaking due to trying to retrieve an incorrect issuer. This PR will fix the issue by correctly setting the issuer.