### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -298,6 +298,11 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- for Java 17 Compatibility -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,12 @@
                 <artifactId>org.wso2.carbon.identity.saml.common.util</artifactId>
                 <version>${saml.common.util.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
+                <scope>test</scope>
+            </dependency>
 
             <!-- Pax Logging -->
             <dependency>
@@ -436,17 +442,17 @@
     <properties>
         <carbon.kernel.version>4.7.1</carbon.kernel.version>
         <carbon.kernel.feature.version>4.7.1</carbon.kernel.feature.version>
-        <carbon.identity.framework.version>5.23.14</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 7.0.0)
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
         <identity.inbound.auth.saml.version>${project.version}</identity.inbound.auth.saml.version>
         <identity.inbound.auth.saml.exp.version>${identity.inbound.auth.saml.version}
         </identity.inbound.auth.saml.exp.version>
-        <identity.inbound.auth.saml.imp.pkg.version.range>[5.6.0, 6.0.0)
+        <identity.inbound.auth.saml.imp.pkg.version.range>[6.0.0, 7.0.0)
         </identity.inbound.auth.saml.imp.pkg.version.range>
-        <identity.metadata.saml2.version>1.3.0</identity.metadata.saml2.version>
-        <identity.metadata.saml2.imp.pkg.version.range>[1.3.0, 2.0.0)</identity.metadata.saml2.imp.pkg.version.range>
+        <identity.metadata.saml2.version>2.0.0</identity.metadata.saml2.version>
+        <identity.metadata.saml2.imp.pkg.version.range>[2.0.0, 3.0.0)</identity.metadata.saml2.imp.pkg.version.range>
 
         <httpcore.version>4.4.14.wso2v1</httpcore.version>
         <httpcomponents-httpclient.wso2.version>4.5.13.wso2v1</httpcomponents-httpclient.wso2.version>
@@ -462,7 +468,7 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
-        <carbon.identity.package.import.version.range>[5.0.0, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.package.import.version.range>
 
         <osgi.service.http.imp.pkg.version.range>[1.2.1, 2.0.0)</osgi.service.http.imp.pkg.version.range>
         <osgi.util.tracker.imp.pkg.version.range>[1.5.1, 2.0.0)</osgi.util.tracker.imp.pkg.version.range>
@@ -503,6 +509,8 @@
         <xercesImpl.version>2.12.2</xercesImpl.version>
 
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
+        <org.wso2.carbon.identity.organization.management.core.version>2.0.0
+        </org.wso2.carbon.identity.organization.management.core.version>
 
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16