### PR TITLE
Fixing InboundConfiguration property export structure

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -315,6 +315,11 @@
             <artifactId>org.wso2.carbon.identity.testutil</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
@@ -17,8 +17,10 @@
  */
 package org.wso2.carbon.identity.sso.saml.dto;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.common.model.InboundConfigurationProtocol;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 
 import java.io.Serializable;
@@ -28,15 +30,20 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
-@XmlRootElement
+/**
+ * This class is used to store the SAML SSO Service Provider related information.
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
-public class SAMLSSOServiceProviderDTO implements Serializable {
+@XmlRootElement(name = "samlssoServiceProviderDTO")
+@JsonTypeName("samlssoServiceProviderDTO")
+public class SAMLSSOServiceProviderDTO extends InboundConfigurationProtocol implements Serializable {
+
 
     private static final long serialVersionUID = -7633935958583257097L;
 
     private String issuer;
     private String issuerQualifier;
-    @XmlElementWrapper(name="assertionConsumerUrls")
+    @XmlElementWrapper(name = "assertionConsumerUrls")
     @XmlElement(name = "assertionConsumerUrl")
     private String[] assertionConsumerUrls;
     private String defaultAssertionConsumerUrl;
@@ -52,13 +59,13 @@ public class SAMLSSOServiceProviderDTO implements Serializable {
     private boolean doSignAssertions;
     private boolean doSignResponse;
     private boolean doFrontChannelLogout;
-    @XmlElementWrapper(name="requestedClaims")
+    @XmlElementWrapper(name = "requestedClaims")
     @XmlElement(name = "requestedClaim")
     private String[] requestedClaims;
-    @XmlElementWrapper(name="requestedAudiences")
+    @XmlElementWrapper(name = "requestedAudiences")
     @XmlElement(name = "requestedAudience")
     private String[] requestedAudiences;
-    @XmlElementWrapper(name="requestedRecipients")
+    @XmlElementWrapper(name = "requestedRecipients")
     @XmlElement(name = "requestedRecipient")
     private String[] requestedRecipients;
     private boolean enableAttributeProfile;
@@ -69,7 +76,7 @@ public class SAMLSSOServiceProviderDTO implements Serializable {
     private String nameIDFormat;
     private boolean idPInitSSOEnabled;
     private boolean idPInitSLOEnabled;
-    @XmlElementWrapper(name="idpInitSLOReturnToURLs")
+    @XmlElementWrapper(name = "idpInitSLOReturnToURLs")
     @XmlElement(name = "idpInitSLOReturnToURL")
     private String[] idpInitSLOReturnToURLs;
     private boolean doEnableEncryptedAssertion;
@@ -439,7 +446,7 @@ public class SAMLSSOServiceProviderDTO implements Serializable {
 
     public void setIdpInitSLOReturnToURLs(String[] idpInitSLOReturnToURLs) {
 
-        if(idpInitSLOReturnToURLs != null) {
+        if (idpInitSLOReturnToURLs != null) {
             this.idpInitSLOReturnToURLs = idpInitSLOReturnToURLs.clone();
         } else {
             this.idpInitSLOReturnToURLs = null;
@@ -486,7 +493,7 @@ public class SAMLSSOServiceProviderDTO implements Serializable {
     }
 
     /**
-     * Get idp entity id alias value
+     * Get idp entity id alias value.
      *
      * @return
      */
@@ -496,7 +503,7 @@ public class SAMLSSOServiceProviderDTO implements Serializable {
     }
 
     /**
-     * Set idp entity id alias value
+     * Set idp entity id alias value.
      *
      * @param idpEntityIDAlias
      */

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/SAMLApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/SAMLApplicationMgtListener.java
@@ -236,11 +236,10 @@ public class SAMLApplicationMgtListener extends AbstractApplicationMgtListener {
                                         serviceProvider.getOwner().getTenantDomain());
             authConfig.setInboundConfigurationProtocol(samlssoServiceProviderDTO);
             return samlssoServiceProviderDTO;
-        } else {
-            String errorMsg = String.format("No inbound configurations found for saml in the" +
-                    " imported %s", serviceProvider.getApplicationName());
-            throw new IdentityApplicationManagementException(errorMsg);
         }
+        String errorMsg = String.format("No inbound configurations found for saml in the imported %s",
+                                        serviceProvider.getApplicationName());
+        throw new IdentityApplicationManagementException(errorMsg);
     }
 
     public void doExportServiceProvider(ServiceProvider serviceProvider, Boolean exportSecrets)

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/SAMLApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/SAMLApplicationMgtListener.java
@@ -37,14 +37,12 @@ import org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtil;
 import org.wso2.carbon.registry.core.Registry;
 
 import java.io.ByteArrayInputStream;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
 /**
@@ -189,7 +187,7 @@ public class SAMLApplicationMgtListener extends AbstractApplicationMgtListener {
                                 (SAMLSSOServiceProviderDTO) authConfig.getInboundConfigurationProtocol();
 
                         if (samlssoServiceProviderDTO == null) {
-                            String errorMsg = String.format("No inbound configurations found for smal in the" +
+                            String errorMsg = String.format("No inbound configurations found for saml in the" +
                                             " imported %s", serviceProvider.getApplicationName());
                             throw new IdentityApplicationManagementException(errorMsg);
                         }
@@ -259,12 +257,6 @@ public class SAMLApplicationMgtListener extends AbstractApplicationMgtListener {
                             throw new IdentityApplicationManagementException(String.format("There is no saml " +
                                     "configured with %s", authConfig.getInboundAuthKey()));
                         }
-                        JAXBContext jaxbContext = JAXBContext.newInstance(SAMLSSOServiceProviderDTO.class);
-                        Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
-                        jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-                        StringWriter sw = new StringWriter();
-                        jaxbMarshaller.marshal(samlSP, sw);
-                        authConfig.setInboundConfiguration(sw.toString());
 
                         authConfig.setInboundConfigurationProtocol(samlSP);
                         return;
@@ -273,9 +265,6 @@ public class SAMLApplicationMgtListener extends AbstractApplicationMgtListener {
             }
         } catch (IdentityException e) {
             throw new IdentityApplicationManagementException("Error occurred when retrieving SAML application ", e);
-        } catch (JAXBException e) {
-            throw new IdentityApplicationManagementException(String.format("Error in exporting SAML application " +
-                    "%s@%s", serviceProvider.getApplicationName(), serviceProvider.getOwner().getTenantDomain()), e);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@
     <properties>
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
-        <carbon.identity.framework.version>5.23.14</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.157</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,12 @@
                 <artifactId>xercesImpl</artifactId>
                 <version>${xercesImpl.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <scope>test</scope>
+                <version>${carbon.identity.organization.management.core.version}</version>
+            </dependency>
         </dependencies>
 
     </dependencyManagement>
@@ -449,6 +455,7 @@
         <carbon.identity.framework.version>5.25.157</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
+        <carbon.identity.organization.management.core.version>1.0.0</carbon.identity.organization.management.core.version>
 
         <identity.inbound.auth.saml.version>${project.version}</identity.inbound.auth.saml.version>
         <identity.inbound.auth.saml.exp.version>${identity.inbound.auth.saml.version}


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/product-is/issues/15683

This PR resolves the issue of inboundConfiguration property being exported as an XML string instead of being broken down into properties when exporting service providers through the API.

## Goals
When exporting service providers through the API, the "inboundConfiguration" property is exported broken down into individual properties.

## Approach
inboundConfigurationProtocol abstract class property is added and inboundConfiguration is ignored during serialization. samlssoServiceProviderDTO class is updated to extend the new inboundConfigurationProtocol class.

## Related PRs
https://github.com/wso2/carbon-identity-framework/pull/4505
https://github.com/wso2/identity-api-server/pull/437
https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2047

**Need to bump framework version after merging the following PR:**
https://github.com/wso2/carbon-identity-framework/pull/4505