### PR TITLE
Add doSignResponse property to session during IDP Initiated SSO Flow

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -68,6 +68,7 @@ public class SAMLSSOConstants {
     public static final String SAML2_AUTHENTICATION_REQUEST_VALIDITY_PERIOD_ENABLED = "SSOService.SAML2AuthenticationRequestValidityPeriodEnabled";
     public static final String SAML2_AUTHENTICATION_REQUEST_VALIDITY_PERIOD = "SSOService.SAML2AuthenticationRequestValidityPeriod";
     public static final String SAML_SP_CERTIFICATE_EXPIRY_VALIDATION_ENABLED = "SSOService.SAMLSPCertificateExpiryValidationEnable";
+    public static final String SAML_IDP_INIT_LOGOUT_RESPONSE_SIGNING_ENABLED = "SSOService.SAMLIdpInitLogoutResponseSigningEnabled";
     public static final String SAML_ASSERTION_ENCRYPT_WITH_APP_CERT = "SSOService.SAMLAssertionEncyptWithAppCert";
     public static final String START_SOAP_BINDING = "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
             "<SOAP-ENV:Body>";

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitSSOAuthnRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitSSOAuthnRequestProcessor.java
@@ -135,6 +135,7 @@ public class IdPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor
                     spDO.setIdPInitSLOEnabled(authnReqDTO.isIdPInitSLOEnabled());
                     spDO.setAssertionConsumerUrls(authnReqDTO.getAssertionConsumerURLs());
                     spDO.setIdpInitSLOReturnToURLs(authnReqDTO.getIdpInitSLOReturnToURLs());
+                    spDO.setDoSignResponse(authnReqDTO.isDoSignResponse());
                     spDO.setSigningAlgorithmUri(authnReqDTO.getSigningAlgorithmUri());
                     spDO.setDigestAlgorithmUri(authnReqDTO.getDigestAlgorithmUri());
                     spDO.setAssertionEncryptionAlgorithmUri(authnReqDTO.getAssertionEncryptionAlgorithmUri());

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitSSOAuthnRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitSSOAuthnRequestProcessor.java
@@ -135,7 +135,6 @@ public class IdPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor
                     spDO.setIdPInitSLOEnabled(authnReqDTO.isIdPInitSLOEnabled());
                     spDO.setAssertionConsumerUrls(authnReqDTO.getAssertionConsumerURLs());
                     spDO.setIdpInitSLOReturnToURLs(authnReqDTO.getIdpInitSLOReturnToURLs());
-                    spDO.setDoSignResponse(authnReqDTO.isDoSignResponse());
                     spDO.setSigningAlgorithmUri(authnReqDTO.getSigningAlgorithmUri());
                     spDO.setDigestAlgorithmUri(authnReqDTO.getDigestAlgorithmUri());
                     spDO.setAssertionEncryptionAlgorithmUri(authnReqDTO.getAssertionEncryptionAlgorithmUri());
@@ -143,6 +142,9 @@ public class IdPInitSSOAuthnRequestProcessor implements SSOAuthnRequestProcessor
                     spDO.setEnableSAML2ArtifactBinding(authnReqDTO.isSAML2ArtifactBindingEnabled());
                     spDO.setDoValidateSignatureInRequests(authnReqDTO.isDoValidateSignatureInRequests());
                     spDO.setDoValidateSignatureInArtifactResolve(authnReqDTO.isDoValidateSignatureInArtifactResolve());
+                    if (SAMLSSOUtil.isSAMLIdpInitLogoutResponseSigningEnabled()) {
+                        spDO.setDoSignResponse(authnReqDTO.isDoSignResponse());
+                    }
                     sessionPersistenceManager.persistSession(sessionIndexId,
                             authnReqDTO.getUser().getAuthenticatedSubjectIdentifier(), spDO,
                             authnReqDTO.getRpSessionId(), authnReqDTO.getIssuer(),

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -2691,4 +2691,14 @@ public class SAMLSSOUtil {
             PrivilegedCarbonContext.endTenantFlow();
         }
     }
+
+    /**
+     * Check whether SAML logout response signing is enabled for IDP initiated SSO.
+     * @return true if enabled.
+     */
+    public static boolean isSAMLIdpInitLogoutResponseSigningEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(
+                SAMLSSOConstants.SAML_IDP_INIT_LOGOUT_RESPONSE_SIGNING_ENABLED));
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@
     <properties>
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
-        <carbon.identity.framework.version>5.25.247</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.260</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.organization.management.core.version>1.0.0</carbon.identity.organization.management.core.version>


### PR DESCRIPTION
When populating the SAMLSSOServiceProviderDO before adding it to session data, we have missed setting the `isDoSignResponse` property from the authnReqDTO during the IDP initiated SSO authentication flow. Therefore during logout flow, the default value - false is set for this property when loaded from session data, and therefore the response will not be signed.

This PR will set the DoSignResponse to SAMLSSOServiceProviderDO during SSO Auth request processing flow so that this property will be loaded correctly during logout.

This PR introduces a new config to disable signing the logout response after IDP initiated SSO logins, to preserve backward compatibility. This config will be checked before setting the above parameter.
By default, the SAML **logout** response for SP initiated SSO and IDP initiated SSO login flows will be signed if the `Enable Response Signing` property is enabled in the Service Provider. But if a customer requires the previous behaviour where the SAML logout response during IDP initiated SSO flow is not signed, the following config can be added to the deployment.toml.

```
[saml]
enable_saml_idp_init_logout_response_signing = false
```

Related Issue: https://github.com/wso2/product-is/issues/16207
Related PR: Bump framework after merging https://github.com/wso2/carbon-identity-framework/pull/4803