### PR TITLE
Migrate security-mgt module from framework to its own group.

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -426,8 +426,9 @@
                             org.wso2.carbon.identity.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.handler; version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.security,
-                            org.wso2.carbon.security.keystore,
+                            org.wso2.carbon.security; version="${carbon.security.keystore.service.version.range}",
+                            org.wso2.carbon.security.keystore;
+                            version="${carbon.security.keystore.service.version.range}",
                             org.wso2.carbon.security.keystore.service;
                             version="${carbon.security.keystore.service.version.range}",
                         </Import-Package>

--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -417,9 +417,6 @@
                             org.wso2.carbon.identity.core.dao; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.persistence; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.security; version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.security.keystore; version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.security.keystore.service; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.user.core,
                             org.wso2.carbon.user.core.claim,
                             org.wso2.carbon.user.core.service,
@@ -429,7 +426,10 @@
                             org.wso2.carbon.identity.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.handler; version="${carbon.identity.package.import.version.range}",
-
+                            org.wso2.carbon.security,
+                            org.wso2.carbon.security.keystore,
+                            org.wso2.carbon.security.keystore.service;
+                            version="${carbon.security.keystore.service.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.sso.saml.internal,

--- a/pom.xml
+++ b/pom.xml
@@ -480,6 +480,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
         <carbon.identity.package.import.version.range>[5.0.0, 7.0.0)</carbon.identity.package.import.version.range>
+        <carbon.security.keystore.service.version.range>[1.0.0, 2.0.0)</carbon.security.keystore.service.version.range>
 
         <osgi.service.http.imp.pkg.version.range>[1.2.1, 2.0.0)</osgi.service.http.imp.pkg.version.range>
         <osgi.util.tracker.imp.pkg.version.range>[1.5.1, 2.0.0)</osgi.util.tracker.imp.pkg.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR contains the changes made to migrate the security-mgt component from framework and move it to new carbon.security.mgt group. This is a milestone of the following issue[1].

### Related Issues
- https://github.com/wso2/product-is/issues/16422

### NOTE:
- Product IS PR builder will fail because the the security-mgt component used there is still old version. 
