### PR TITLE
Fix the SAML client requests  as client exceptions instead of server exceptions

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -532,7 +532,7 @@ public class SAMLSSOUtil {
             throw new IdentitySAML2ClientException("Error when decoding the SAML Request. " +
                     "Invalid arguments provided.", e);
         } catch (IOException e) {
-            throw IdentityException.error("Error when decoding the SAML Request.", e);
+            throw new IdentitySAML2ClientException("Error when decoding the SAML Request.", e);
         }
 
     }


### PR DESCRIPTION
This PR contains the fix for handling malformed SAML client requests as client exceptions instead of server exceptions and on top of this fix https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/392,  handle the client exception in the decoding method when malformed SAML request received from the client side.


