### PR TITLE
Revert "Migrate security-mgt module from framework to its own group."

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -422,6 +422,9 @@
                             org.wso2.carbon.identity.core.dao; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.persistence; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security.keystore; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security.keystore.service; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.user.core,
                             org.wso2.carbon.user.core.claim,
                             org.wso2.carbon.user.core.service,
@@ -431,11 +434,6 @@
                             org.wso2.carbon.identity.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.handler; version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.security; version="${carbon.security.keystore.service.version.range}",
-                            org.wso2.carbon.security.keystore;
-                            version="${carbon.security.keystore.service.version.range}",
-                            org.wso2.carbon.security.keystore.service;
-                            version="${carbon.security.keystore.service.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.sso.saml.internal,

--- a/pom.xml
+++ b/pom.xml
@@ -486,7 +486,6 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
         <carbon.identity.package.import.version.range>[5.0.0, 7.0.0)</carbon.identity.package.import.version.range>
-        <carbon.security.keystore.service.version.range>[1.0.0, 2.0.0)</carbon.security.keystore.service.version.range>
 
         <osgi.service.http.imp.pkg.version.range>[1.2.1, 2.0.0)</osgi.service.http.imp.pkg.version.range>
         <osgi.util.tracker.imp.pkg.version.range>[1.5.1, 2.0.0)</osgi.util.tracker.imp.pkg.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
-        <carbon.identity.framework.version>5.25.260</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.305</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.260, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.organization.management.core.version>1.0.0</carbon.identity.organization.management.core.version>


### PR DESCRIPTION
Revert https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/401

Related issues:
- https://github.com/wso2/product-is/issues/16422