### PR TITLE
Improve tenant resolving with tenant qualified URL enabled.

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLLogoutHandler.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLLogoutHandler.java
@@ -137,7 +137,7 @@ public class SAMLLogoutHandler extends AbstractEventHandler {
         }
 
         if (StringUtils.isBlank(loggedInTenantDomain)) {
-            loggedInTenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+            loggedInTenantDomain = IdentityTenantUtil.resolveTenantDomain();
         }
         return loggedInTenantDomain;
     }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -276,7 +276,7 @@ public class SAMLSSOService {
 
         String loginTenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
         if (IdentityTenantUtil.isTenantedSessionsEnabled()) {
-            loginTenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+            loginTenantDomain = IdentityTenantUtil.resolveTenantDomain();
         }
         SPInitLogoutRequestProcessor logoutReqProcessor = SAMLSSOUtil.getSPInitLogoutRequestProcessor();
         return logoutReqProcessor.process(null, sessionId, null, loginTenantDomain);

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
@@ -211,7 +211,7 @@ public class SAMLSSOConfigAdmin {
         if (!IdentityTenantUtil.isTenantedSessionsEnabled()) {
             return getTenantDomain();
         }
-        return IdentityTenantUtil.getTenantDomainFromContext();
+        return IdentityTenantUtil.resolveTenantDomain();
     }
 
     private Optional<AuthenticatedUser> getLoggedInUser(String tenantDomain) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -241,7 +241,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
 
             String tenantDomain = null;
             if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-                tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+                tenantDomain = IdentityTenantUtil.resolveTenantDomain();
                 if (log.isDebugEnabled()) {
                     log.debug("Tenant domain from context: " + tenantDomain);
                 }
@@ -2243,7 +2243,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
 
         String loggedInTenantDomain = req.getParameter(FrameworkConstants.RequestParams.LOGIN_TENANT_DOMAIN);
         if (StringUtils.isBlank(loggedInTenantDomain)) {
-            return IdentityTenantUtil.getTenantDomainFromContext();
+            return IdentityTenantUtil.resolveTenantDomain();
         }
         return loggedInTenantDomain;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
-        <carbon.identity.framework.version>5.25.305</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.380</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.260, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.organization.management.core.version>1.0.0</carbon.identity.organization.management.core.version>


### PR DESCRIPTION
Related issue:
- https://github.com/wso2/product-is/issues/16906

Improve resolving tenant domain when tenant qualified URL feature is enabled. If the tenant domain is available in the context retrieve it otherwise retrieve tenant domain from the privileged carbon context.