### PR TITLE
Improve Tenant Resolving Logic during logout for Tenant Qualified URLs

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -2240,12 +2240,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         if (!IdentityTenantUtil.isTenantedSessionsEnabled()) {
             return SAMLSSOUtil.getTenantDomainFromThreadLocal();
         }
-
-        String loggedInTenantDomain = req.getParameter(FrameworkConstants.RequestParams.LOGIN_TENANT_DOMAIN);
-        if (StringUtils.isBlank(loggedInTenantDomain)) {
-            return IdentityTenantUtil.resolveTenantDomain();
-        }
-        return loggedInTenantDomain;
+        return IdentityTenantUtil.resolveTenantDomain();
     }
 
     /**


### PR DESCRIPTION
This PR will use the resolveTenantDomain method in IdentityTenantUtil to resolve the tenant domain of tenant qualified URLs. When tenant qualified URLs and tenanted sessions are enabled, the super tenant urls will not contain the tenant domain in the request path. Therefore the request will not be used to derive tenant domain, instead it will be retrieved from the context.

Related issue: https://github.com/wso2/product-is/issues/16906