### PR TITLE
Improve setting cookie path for the super tenant

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -1503,7 +1503,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         if (IdentityTenantUtil.isTenantedSessionsEnabled() &&
                 sessionId.endsWith(SAMLSSOConstants.TENANT_QUALIFIED_TOKEN_ID_COOKIE_SUFFIX)) {
             if (loggedInTenantDomain != null) {
-                if (!IdentityTenantUtil.isSuperTenantRequiredInUrl() &&
+                if (!IdentityTenantUtil.isSuperTenantAppendInCookiePath() &&
                         MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(loggedInTenantDomain)) {
                     samlssoTokenIdCookie.setPath(SAMLSSOConstants.COOKIE_ROOT_PATH);
                 } else {
@@ -1511,7 +1511,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                             SAMLSSOConstants.COOKIE_ROOT_PATH);
                 }
             } else {
-                if (!IdentityTenantUtil.isSuperTenantRequiredInUrl() &&
+                if (!IdentityTenantUtil.isSuperTenantAppendInCookiePath() &&
                         MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
                     samlssoTokenIdCookie.setPath(SAMLSSOConstants.COOKIE_ROOT_PATH);
                 } else {
@@ -1571,7 +1571,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                     if (IdentityTenantUtil.isTenantedSessionsEnabled() && cookie.getValue() != null &&
                             cookie.getValue().endsWith(SAMLSSOConstants.TENANT_QUALIFIED_TOKEN_ID_COOKIE_SUFFIX)) {
 
-                        if (!IdentityTenantUtil.isSuperTenantRequiredInUrl() &&
+                        if (!IdentityTenantUtil.isSuperTenantAppendInCookiePath() &&
                                 MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(loggedInTenantDomain)) {
                             samlSsoTokenIdCookie.setPath(SAMLSSOConstants.COOKIE_ROOT_PATH);
                         } else {

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
-        <carbon.identity.framework.version>5.25.406</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.507</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.260, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.organization.management.core.version>1.0.0</carbon.identity.organization.management.core.version>


### PR DESCRIPTION
Add a new config "TenantContext.TenantQualifiedUrls.AppendSuperTenantInCookiePath" to specify whether to append the `carbon.super` in the cookie paths and if enabled append the `carbon.super` to the cookie path.