### PR TITLE
Add `IsPassive` support in SAML IDP initiated flow

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2010, WSO2 LLC. (http://www.wso2.org).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -126,7 +126,8 @@ public class SAMLSSOConstants {
         SLO("slo"),
         RETURN_TO("returnTo"),
         SP_ENTITY_ID("spEntityID"),
-        SP_QUALIFIER("spQualifier");
+        SP_QUALIFIER("spQualifier"),
+        IS_PASSIVE("IsPassive");
 
         private final String parameterName;
 

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -178,11 +178,43 @@ public class SAMLSSOService {
                                                                      QueryParamDTO[] queryParamDTOs,
                                                                      String serverURL, String sessionId,
                                                                      String rpSessionId, String authnMode,
-                                                                     boolean isLogout, boolean isPassive) throws IdentityException {
+                                                                     boolean isLogout) throws IdentityException {
 
         // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
         return validateIdPInitSSORequest(relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId,
-                authnMode, isLogout, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, isPassive);
+                authnMode, isLogout, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * validates the IdP Initiated SSO/SLO request.
+     * If the user already have a SSO session then the Response
+     * will be returned if not only the validation results will be returned.
+     *
+     * @param relayState
+     * @param queryString
+     * @param queryParamDTOs
+     * @param serverURL
+     * @param sessionId
+     * @param rpSessionId
+     * @param authnMode
+     * @param isLogout
+     * @return
+     * @throws IdentityException
+     *
+     * @deprecated This method was deprecated to support IsPassive.
+     * Use {@link #validateIdPInitSSORequest(String,String,QueryParamDTO[],
+     * String,String,String,String,boolean,String,boolean)} instead.
+     */
+    public SAMLSSOReqValidationResponseDTO validateIdPInitSSORequest(String relayState, String queryString,
+                                                                     QueryParamDTO[] queryParamDTOs,
+                                                                     String serverURL, String sessionId,
+                                                                     String rpSessionId, String authnMode,
+                                                                     boolean isLogout, String loginTenantDomain)
+            throws IdentityException {
+
+        // For backward compatibility, the IsPassive param is set to false by default.
+        return validateIdPInitSSORequest(relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId,
+                authnMode, isLogout, loginTenantDomain, false);
     }
 
     /**
@@ -199,6 +231,7 @@ public class SAMLSSOService {
      * @param authnMode             Authn Mode
      * @param isLogout              Is Logout
      * @param loginTenantDomain     Login tenant Domain
+     * @param isPassive             Is Passive
      * @return      validationResponseDTO
      * @throws IdentityException
      */

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -178,11 +178,11 @@ public class SAMLSSOService {
                                                                      QueryParamDTO[] queryParamDTOs,
                                                                      String serverURL, String sessionId,
                                                                      String rpSessionId, String authnMode,
-                                                                     boolean isLogout) throws IdentityException {
+                                                                     boolean isLogout, String isPassive) throws IdentityException {
 
         // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
         return validateIdPInitSSORequest(relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId,
-                authnMode, isLogout, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+                authnMode, isLogout, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, isPassive);
     }
 
     /**
@@ -206,7 +206,8 @@ public class SAMLSSOService {
                                                                      QueryParamDTO[] queryParamDTOs,
                                                                      String serverURL, String sessionId,
                                                                      String rpSessionId, String authnMode,
-                                                                     boolean isLogout, String loginTenantDomain)
+                                                                     boolean isLogout, String loginTenantDomain,
+                                                                     String isPassive)
             throws IdentityException {
 
         SAMLSSOReqValidationResponseDTO validationResponseDTO = null;
@@ -224,6 +225,7 @@ public class SAMLSSOService {
         }
         validationResponseDTO.setQueryString(queryString);
         validationResponseDTO.setRpSessionId(rpSessionId);
+        validationResponseDTO.setPassive(Boolean.valueOf(isPassive));
         return validationResponseDTO;
     }
 

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2010, WSO2 LLC. (http://www.wso2.org).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -178,7 +178,7 @@ public class SAMLSSOService {
                                                                      QueryParamDTO[] queryParamDTOs,
                                                                      String serverURL, String sessionId,
                                                                      String rpSessionId, String authnMode,
-                                                                     boolean isLogout, String isPassive) throws IdentityException {
+                                                                     boolean isLogout, boolean isPassive) throws IdentityException {
 
         // For backward compatibility, SUPER_TENANT_DOMAIN was used as the cache maintaining tenant.
         return validateIdPInitSSORequest(relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId,
@@ -207,7 +207,7 @@ public class SAMLSSOService {
                                                                      String serverURL, String sessionId,
                                                                      String rpSessionId, String authnMode,
                                                                      boolean isLogout, String loginTenantDomain,
-                                                                     String isPassive)
+                                                                     boolean isPassive)
             throws IdentityException {
 
         SAMLSSOReqValidationResponseDTO validationResponseDTO = null;
@@ -225,7 +225,7 @@ public class SAMLSSOService {
         }
         validationResponseDTO.setQueryString(queryString);
         validationResponseDTO.setRpSessionId(rpSessionId);
-        validationResponseDTO.setPassive(Boolean.valueOf(isPassive));
+        validationResponseDTO.setPassive(isPassive);
         return validationResponseDTO;
     }
 

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -190,17 +190,17 @@ public class SAMLSSOService {
      * If the user already have a SSO session then the Response
      * will be returned if not only the validation results will be returned.
      *
-     * @param relayState            Relay state
-     * @param queryString           Query string
-     * @param queryParamDTOs        Query param DTOs
-     * @param serverURL             Server url
-     * @param sessionId             Session id
-     * @param rpSessionId           Rp session id
-     * @param authnMode             Authentication mode
-     * @param isLogout              Is logout
-     * @param loginTenantDomain     Login tenant domain
+     * @param relayState            The relay state value used in SSO/SLO process, typically a unique identifier.
+     * @param queryString           The complete query string from the SSO/SLO request.
+     * @param queryParamDTOs        An array of QueryParamDTO objects representing the query parameters.
+     * @param serverURL             The URL of the server where SSO/SLO request is processed.
+     * @param sessionId             The session identifier for the user's current session.
+     * @param rpSessionId           The session identifier for the relying party's session.
+     * @param authnMode             The authentication mode used in the SSO/SLO process.
+     * @param isLogout              Boolean flag indicating whether the request is for logout.
+     * @param loginTenantDomain     The domain of the tenant in which the user is attempting to log in.
      * @return
-     * @throws IdentityException
+     * @throws IdentityException    If any error occurs during the validation of the IdP Initiated SSO/SLO request.
      *
      * @deprecated This method was deprecated to support IsPassive.
      * Use {@link #validateIdPInitSSORequest(String,String,QueryParamDTO[],
@@ -223,18 +223,18 @@ public class SAMLSSOService {
      * If the user already having a SSO session then the Response
      * will be returned if not only the validation results will be returned.
      *
-     * @param relayState            Relay State
-     * @param queryString           Query String
-     * @param queryParamDTOs        Query Param DTOs
-     * @param serverURL             Server url
-     * @param sessionId             Session id
-     * @param rpSessionId           Rp Session id
-     * @param authnMode             Authn Mode
-     * @param isLogout              Is Logout
-     * @param loginTenantDomain     Login tenant Domain
-     * @param isPassive             Is passive
-     * @return      validationResponseDTO
-     * @throws IdentityException
+     * @param relayState            The relay state value used in SSO/SLO process, typically a unique identifier.
+     * @param queryString           The complete query string from the SSO/SLO request.
+     * @param queryParamDTOs        An array of QueryParamDTO objects representing the query parameters.
+     * @param serverURL             The URL of the server where SSO/SLO request is processed.
+     * @param sessionId             The session identifier for the user's current session.
+     * @param rpSessionId           The session identifier for the relying party's session.
+     * @param authnMode             The authentication mode used in the SSO/SLO process.
+     * @param isLogout              Boolean flag indicating whether the request is for logout.
+     * @param loginTenantDomain     The domain of the tenant in which the user is attempting to log in.
+     * @param isPassive             A boolean indicating whether the request is passive.
+     * @return validationResponseDTO
+     * @throws IdentityException    If any error occurs during the validation of the IdP Initiated SSO/SLO request.
      */
     public SAMLSSOReqValidationResponseDTO validateIdPInitSSORequest(String relayState, String queryString,
                                                                      QueryParamDTO[] queryParamDTOs,

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -190,14 +190,15 @@ public class SAMLSSOService {
      * If the user already have a SSO session then the Response
      * will be returned if not only the validation results will be returned.
      *
-     * @param relayState
-     * @param queryString
-     * @param queryParamDTOs
-     * @param serverURL
-     * @param sessionId
-     * @param rpSessionId
-     * @param authnMode
-     * @param isLogout
+     * @param relayState            Relay State
+     * @param queryString           Query String
+     * @param queryParamDTOs        Query Param DTOs
+     * @param serverURL             Server url
+     * @param sessionId             Session id
+     * @param rpSessionId           Rp Session id
+     * @param authnMode             Authentication Mode
+     * @param isLogout              Is Logout
+     * @param loginTenantDomain     Login tenant Domain
      * @return
      * @throws IdentityException
      *

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOService.java
@@ -190,15 +190,15 @@ public class SAMLSSOService {
      * If the user already have a SSO session then the Response
      * will be returned if not only the validation results will be returned.
      *
-     * @param relayState            Relay State
-     * @param queryString           Query String
-     * @param queryParamDTOs        Query Param DTOs
+     * @param relayState            Relay state
+     * @param queryString           Query string
+     * @param queryParamDTOs        Query param DTOs
      * @param serverURL             Server url
      * @param sessionId             Session id
-     * @param rpSessionId           Rp Session id
-     * @param authnMode             Authentication Mode
-     * @param isLogout              Is Logout
-     * @param loginTenantDomain     Login tenant Domain
+     * @param rpSessionId           Rp session id
+     * @param authnMode             Authentication mode
+     * @param isLogout              Is logout
+     * @param loginTenantDomain     Login tenant domain
      * @return
      * @throws IdentityException
      *
@@ -232,7 +232,7 @@ public class SAMLSSOService {
      * @param authnMode             Authn Mode
      * @param isLogout              Is Logout
      * @param loginTenantDomain     Login tenant Domain
-     * @param isPassive             Is Passive
+     * @param isPassive             Is passive
      * @return      validationResponseDTO
      * @throws IdentityException
      */

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -224,6 +224,8 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         String relayState = req.getParameter(SAMLSSOConstants.RELAY_STATE);
         String spEntityID = req.getParameter(SAMLSSOConstants.QueryParameter
                 .SP_ENTITY_ID.toString());
+        String isPassive = req.getParameter(SAMLSSOConstants.QueryParameter
+                .IS_PASSIVE.toString());
         String samlRequest = req.getParameter(SAMLSSOConstants.SAML_REQUEST);
         String samlResponse = req.getParameter(SAMLSSOConstants.SAML_RESP);
         String sessionDataKey = getSessionDataKey(req);
@@ -308,7 +310,8 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                     return;
                 }
             } else if (spEntityID != null || slo != null) { // idp initiated SSO/SLO
-                handleIdPInitSSO(req, resp, relayState, queryString, authMode, sessionId, isPost, (slo != null));
+                handleIdPInitSSO(req, resp, relayState, queryString, authMode, sessionId, isPost,
+                        (slo != null), isPassive);
             } else if (samlRequest != null) {// SAMLRequest received. SP initiated SSO
                 handleSPInitSSO(req, resp, queryString, relayState, authMode, samlRequest, sessionId, isPost);
             } else if (samlResponse != null) {// SAMLResponse received.
@@ -649,7 +652,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
 
     private void handleIdPInitSSO(HttpServletRequest req, HttpServletResponse resp, String relayState,
                                   String queryString, String authMode, String sessionId,
-                                  boolean isPost, boolean isLogout) throws UserStoreException, IdentityException,
+                                  boolean isPost, boolean isLogout, String isPassive) throws UserStoreException, IdentityException,
                                                                       IOException, ServletException {
 
         DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;
@@ -671,7 +674,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         String defaultLogoutLocation = FrameworkUtils.getRedirectURL(SAMLSSOUtil.getDefaultLogoutEndpoint(), req);
         SAMLSSOReqValidationResponseDTO signInRespDTO = samlSSOService.validateIdPInitSSORequest(
                 relayState, queryString, getQueryParams(req), defaultLogoutLocation, sessionId, rpSessionId,
-                authMode, isLogout, getLoggedInTenantDomain(req));
+                authMode, isLogout, getLoggedInTenantDomain(req), isPassive);
         setSPAttributeToRequest(req, signInRespDTO.getIssuer(), SAMLSSOUtil.getTenantDomainFromThreadLocal());
 
         if (!signInRespDTO.isLogOutReq()) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -224,8 +224,6 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         String relayState = req.getParameter(SAMLSSOConstants.RELAY_STATE);
         String spEntityID = req.getParameter(SAMLSSOConstants.QueryParameter
                 .SP_ENTITY_ID.toString());
-        boolean isPassive = Boolean.valueOf(req.getParameter(SAMLSSOConstants.QueryParameter
-                .IS_PASSIVE.toString()));
         String samlRequest = req.getParameter(SAMLSSOConstants.SAML_REQUEST);
         String samlResponse = req.getParameter(SAMLSSOConstants.SAML_RESP);
         String sessionDataKey = getSessionDataKey(req);
@@ -310,8 +308,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                     return;
                 }
             } else if (spEntityID != null || slo != null) { // idp initiated SSO/SLO
-                handleIdPInitSSO(req, resp, relayState, queryString, authMode, sessionId, isPost,
-                        (slo != null), isPassive);
+                handleIdPInitSSO(req, resp, relayState, queryString, authMode, sessionId, isPost, (slo != null));
             } else if (samlRequest != null) {// SAMLRequest received. SP initiated SSO
                 handleSPInitSSO(req, resp, queryString, relayState, authMode, samlRequest, sessionId, isPost);
             } else if (samlResponse != null) {// SAMLResponse received.
@@ -652,7 +649,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
 
     private void handleIdPInitSSO(HttpServletRequest req, HttpServletResponse resp, String relayState,
                                   String queryString, String authMode, String sessionId,
-                                  boolean isPost, boolean isLogout, boolean isPassive) throws UserStoreException, IdentityException,
+                                  boolean isPost, boolean isLogout) throws UserStoreException, IdentityException,
                                                                       IOException, ServletException {
 
         DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;
@@ -674,7 +671,8 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         String defaultLogoutLocation = FrameworkUtils.getRedirectURL(SAMLSSOUtil.getDefaultLogoutEndpoint(), req);
         SAMLSSOReqValidationResponseDTO signInRespDTO = samlSSOService.validateIdPInitSSORequest(
                 relayState, queryString, getQueryParams(req), defaultLogoutLocation, sessionId, rpSessionId,
-                authMode, isLogout, getLoggedInTenantDomain(req), isPassive);
+                authMode, isLogout, getLoggedInTenantDomain(req), Boolean.valueOf(req.getParameter
+                        (SAMLSSOConstants.QueryParameter.IS_PASSIVE.toString())));
         setSPAttributeToRequest(req, signInRespDTO.getIssuer(), SAMLSSOUtil.getTenantDomainFromThreadLocal());
 
         if (!signInRespDTO.isLogOutReq()) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -224,8 +224,8 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         String relayState = req.getParameter(SAMLSSOConstants.RELAY_STATE);
         String spEntityID = req.getParameter(SAMLSSOConstants.QueryParameter
                 .SP_ENTITY_ID.toString());
-        String isPassive = req.getParameter(SAMLSSOConstants.QueryParameter
-                .IS_PASSIVE.toString());
+        boolean isPassive = Boolean.valueOf(req.getParameter(SAMLSSOConstants.QueryParameter
+                .IS_PASSIVE.toString()));
         String samlRequest = req.getParameter(SAMLSSOConstants.SAML_REQUEST);
         String samlResponse = req.getParameter(SAMLSSOConstants.SAML_RESP);
         String sessionDataKey = getSessionDataKey(req);
@@ -652,7 +652,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
 
     private void handleIdPInitSSO(HttpServletRequest req, HttpServletResponse resp, String relayState,
                                   String queryString, String authMode, String sessionId,
-                                  boolean isPost, boolean isLogout, String isPassive) throws UserStoreException, IdentityException,
+                                  boolean isPost, boolean isLogout, boolean isPassive) throws UserStoreException, IdentityException,
                                                                       IOException, ServletException {
 
         DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -669,10 +669,10 @@ public class SAMLSSOProviderServlet extends HttpServlet {
         SAMLSSOService samlSSOService = new SAMLSSOService();
 
         String defaultLogoutLocation = FrameworkUtils.getRedirectURL(SAMLSSOUtil.getDefaultLogoutEndpoint(), req);
+        boolean isPassive = Boolean.valueOf(req.getParameter(SAMLSSOConstants.QueryParameter.IS_PASSIVE.toString()));
         SAMLSSOReqValidationResponseDTO signInRespDTO = samlSSOService.validateIdPInitSSORequest(
                 relayState, queryString, getQueryParams(req), defaultLogoutLocation, sessionId, rpSessionId,
-                authMode, isLogout, getLoggedInTenantDomain(req), Boolean.valueOf(req.getParameter
-                        (SAMLSSOConstants.QueryParameter.IS_PASSIVE.toString())));
+                authMode, isLogout, getLoggedInTenantDomain(req), isPassive);
         setSPAttributeToRequest(req, signInRespDTO.getIssuer(), SAMLSSOUtil.getTenantDomainFromThreadLocal());
 
         if (!signInRespDTO.isLogOutReq()) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAMLSSOServiceTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAMLSSOServiceTest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 LLC. (http://www.wso2.org).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -88,6 +88,16 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
                 {TestConstants.ENCODED_REDIRECT_AUTHN_REQUEST,
                         TestConstants.ENCODED_QUERY_STRING_FOR_AUTHN_REQUEST, false}
         };
+    }
+
+    @DataProvider(name = "testValidateIdPInitSSORequestAuthentication")
+    public static Object[][] idpInitAuthRequests() {
+        return new Object[][]{{true}, {false}};
+    }
+
+    @DataProvider(name = "testValidateIdPInitSSORequestLogout")
+    public static Object[][] idpInitLogoutRequests() {
+        return new Object[][]{{true}, {false}};
     }
 
     @ObjectFactory
@@ -185,8 +195,8 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
         return samlssoReqValidationResponseDTO;
     }
 
-    @Test
-    public void testValidateIdPInitSSORequestAuthentication() throws Exception {
+    @Test(dataProvider = "testValidateIdPInitSSORequestAuthentication")
+    public void testValidateIdPInitSSORequestAuthentication(boolean isPassive) throws Exception {
 
         // Inputs for SAMLSSOService's validateIdPInitSSORequest method.
         String relayState = null;
@@ -213,7 +223,7 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
         SAMLSSOService samlssoService = new SAMLSSOService();
         SAMLSSOReqValidationResponseDTO samlssoReqValidationResponseDTO = samlssoService.validateIdPInitSSORequest(
                 relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId, authnMode, isLogout,
-                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME,"false");
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME,isPassive);
         assertTrue(samlssoReqValidationResponseDTO.isValid(), "Should be a valid SAML authentication request.");
         assertTrue(samlssoReqValidationResponseDTO.isIdPInitSSO(), "Should be an IDP initiated SAML SSO request.");
         assertEquals(samlssoReqValidationResponseDTO.getQueryString(), queryString, "Query String should be same as " +
@@ -222,8 +232,8 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
                 "the given input RpSessionId.");
     }
 
-    @Test
-    public void testValidateIdPInitSSORequestLogout() throws Exception {
+    @Test(dataProvider = "testValidateIdPInitSSORequestLogout")
+    public void testValidateIdPInitSSORequestLogout(boolean isPassive) throws Exception {
 
         // Inputs for SAMLSSOService's validateIdPInitSSORequest method.
         String relayState = null;
@@ -249,7 +259,7 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
         SAMLSSOService samlssoService = new SAMLSSOService();
         SAMLSSOReqValidationResponseDTO samlssoReqValidationResponseDTO = samlssoService.validateIdPInitSSORequest(
                 relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId, authnMode, isLogout,
-                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, "false");
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, isPassive);
         assertTrue(samlssoReqValidationResponseDTO.isValid(), "Should be a valid SAML SLO request.");
         assertTrue(samlssoReqValidationResponseDTO.isIdPInitSLO(), "Should be an IDP initiated SLO request");
         assertEquals(samlssoReqValidationResponseDTO.getQueryString(), queryString, "Query String should be same as " +

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAMLSSOServiceTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAMLSSOServiceTest.java
@@ -213,7 +213,7 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
         SAMLSSOService samlssoService = new SAMLSSOService();
         SAMLSSOReqValidationResponseDTO samlssoReqValidationResponseDTO = samlssoService.validateIdPInitSSORequest(
                 relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId, authnMode, isLogout,
-                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME,"false");
         assertTrue(samlssoReqValidationResponseDTO.isValid(), "Should be a valid SAML authentication request.");
         assertTrue(samlssoReqValidationResponseDTO.isIdPInitSSO(), "Should be an IDP initiated SAML SSO request.");
         assertEquals(samlssoReqValidationResponseDTO.getQueryString(), queryString, "Query String should be same as " +
@@ -249,7 +249,7 @@ public class SAMLSSOServiceTest extends PowerMockTestCase {
         SAMLSSOService samlssoService = new SAMLSSOService();
         SAMLSSOReqValidationResponseDTO samlssoReqValidationResponseDTO = samlssoService.validateIdPInitSSORequest(
                 relayState, queryString, queryParamDTOs, serverURL, sessionId, rpSessionId, authnMode, isLogout,
-                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, "false");
         assertTrue(samlssoReqValidationResponseDTO.isValid(), "Should be a valid SAML SLO request.");
         assertTrue(samlssoReqValidationResponseDTO.isIdPInitSLO(), "Should be an IDP initiated SLO request");
         assertEquals(samlssoReqValidationResponseDTO.getQueryString(), queryString, "Query String should be same as " +


### PR DESCRIPTION
With `IsPassive` property true, the login requiest will not redirect to login screen when there is no existing session. Here we are checking if the property is present in the request and adding to the `validationResponseDTO`. 

Fixes issue : https://github.com/wso2/product-is/issues/17705