### PR TITLE
Add protocol config handler

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml.stub/src/main/resources/IdentitySAMLSSOConfigService.wsdl
+++ b/components/org.wso2.carbon.identity.sso.saml.stub/src/main/resources/IdentitySAMLSSOConfigService.wsdl
@@ -237,6 +237,17 @@
                     <xs:element minOccurs="0" name="tenantZero" type="xs:boolean"/>
                 </xs:sequence>
             </xs:complexType>
+            <xs:complexType name="AuditLogDataType">
+                <xs:sequence>
+                    <xs:element name="entry" type="ax2380:MapEntry" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="MapEntry">
+                <xs:sequence>
+                    <xs:element name="key" type="xs:string"/>
+                    <xs:element name="value" type="xs:anyType"/>
+                </xs:sequence>
+            </xs:complexType>
             <xs:complexType name="SAMLSSOServiceProviderDTO">
 <!--                <xs:complexContent>-->
 <!--                    <xs:extension base="ax2381:InboundConfigurationProtocol">-->
@@ -246,6 +257,7 @@
                             <xs:element minOccurs="0" name="assertionEncryptionAlgorithmURI" nillable="true" type="xs:string"/>
                             <xs:element minOccurs="0" name="assertionQueryRequestProfileEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="attributeConsumingServiceIndex" nillable="true" type="xs:string"/>
+                            <xs:element maxOccurs="unbounded" minOccurs="0" name="auditLogData" nillable="true" type="ax2380:AuditLogDataType"/>
                             <xs:element minOccurs="0" name="certAlias" nillable="true" type="xs:string"/>
                             <xs:element minOccurs="0" name="certificateContent" nillable="true" type="xs:string"/>
                             <xs:element minOccurs="0" name="defaultAssertionConsumerUrl" nillable="true" type="xs:string"/>

--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -438,6 +438,7 @@
                             org.wso2.carbon.identity.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.handler; version="${carbon.identity.package.import.version.range}",
+                            com.google.gson;version="${com.google.code.gson.osgi.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.sso.saml.internal,

--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -303,10 +303,14 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>com.google.code.gson</groupId>-->
-<!--            <artifactId>gson</artifactId>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>org.apache.axis2.wso2</groupId>
+            <artifactId>axis2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
 
         <!-- for Java 17 Compatibility -->
         <dependency>

--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -438,7 +438,7 @@
                             org.wso2.carbon.identity.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.handler; version="${carbon.identity.package.import.version.range}",
-                            com.google.gson;version="${com.google.code.gson.osgi.version.range}",
+                            com.google.gson.*;version="${com.google.code.gson.osgi.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.sso.saml.internal,

--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -303,10 +303,10 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.google.code.gson</groupId>-->
+<!--            <artifactId>gson</artifactId>-->
+<!--        </dependency>-->
 
         <!-- for Java 17 Compatibility -->
         <dependency>
@@ -438,7 +438,6 @@
                             org.wso2.carbon.identity.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.handler; version="${carbon.identity.package.import.version.range}",
-                            com.google.gson.*;version="${com.google.code.gson.osgi.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.sso.saml.internal,

--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -303,6 +303,10 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
 
         <!-- for Java 17 Compatibility -->
         <dependency>

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandler.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandler.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandler.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.sso.saml;
 
 import org.apache.commons.lang.StringUtils;
@@ -21,26 +39,50 @@ import org.wso2.carbon.identity.sso.saml.internal.IdentitySAMLSSOServiceComponen
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Optional;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.StandardInboundProtocols.SAML2;
 import static org.wso2.carbon.identity.application.mgt.inbound.InboundFunctions.getInboundAuthKey;
 
+/**
+ * SAML2 inbound authentication configuration handler.
+ */
 public class SAML2InboundAuthConfigHandler implements ApplicationInboundAuthConfigHandler {
     
     private static final String ATTRIBUTE_CONSUMING_SERVICE_INDEX = "attrConsumServiceIndex";
     
+    /**
+     * Checks whether this handler can handle the inbound authentication request.
+     *
+     * @param inboundProtocolsDTO Inbound protocols DTO.
+     * @return True if InboundProtocolDTO contains SAML inbound auth configs.
+     */
     @Override
     public boolean canHandle(InboundProtocolsDTO inboundProtocolsDTO) {
         
         return inboundProtocolsDTO.getInboundProtocolConfigurationMap().containsKey(SAML2);
     }
     
+    /**
+     * Checks whether this handler can handle the inbound authentication request.
+     *
+     * @param protocolName Name of the protocol.
+     * @return True if the protocolName is "samlsso".
+     */
     @Override
     public boolean canHandle(String protocolName) {
         
         return StringUtils.containsIgnoreCase(ApplicationConstants.StandardInboundProtocols.SAML2, protocolName);
     }
     
+    /**
+     * Creates the inbound authentication request config from InboundProtocolConfigurationDTO.
+     *
+     * @param serviceProvider     Service provider.
+     * @param inboundProtocolsDTO Inbound protocols DTO.
+     * @return InboundAuthenticationRequestConfig.
+     * @throws IdentityApplicationManagementException If an error occurs while creating the config.
+     */
     @Override
     public InboundAuthenticationRequestConfig handleConfigCreation(ServiceProvider serviceProvider,
                                                                    InboundProtocolsDTO inboundProtocolsDTO)
@@ -56,6 +98,14 @@ public class SAML2InboundAuthConfigHandler implements ApplicationInboundAuthConf
         }
     }
     
+    /**
+     * Updates the inbound authentication request config from InboundProtocolConfigurationDTO.
+     *
+     * @param serviceProvider                 Service provider.
+     * @param inboundProtocolConfigurationDTO Inbound protocol configuration DTO.
+     * @return InboundAuthenticationRequestConfig.
+     * @throws IdentityApplicationManagementException If an error occurs while updating the config.
+     */
     @Override
     public InboundAuthenticationRequestConfig handleConfigUpdate(
             ServiceProvider serviceProvider, InboundProtocolConfigurationDTO inboundProtocolConfigurationDTO)
@@ -71,6 +121,12 @@ public class SAML2InboundAuthConfigHandler implements ApplicationInboundAuthConf
         }
     }
     
+    /**
+     * Deletes the inbound authentication request config.
+     *
+     * @param issuer Issuer of the SAMl2 application.
+     * @throws IdentityApplicationManagementException If an error occurs while deleting the config.
+     */
     @Override
     public void handleConfigDeletion(String issuer) throws IdentityApplicationManagementException {
         
@@ -82,6 +138,13 @@ public class SAML2InboundAuthConfigHandler implements ApplicationInboundAuthConf
         }
     }
     
+    /**
+     * Retrieves the inbound authentication request config.
+     *
+     * @param issuer Issuer of the SAMl2 application.
+     * @return InboundProtocolConfigurationDTO.
+     * @throws IdentityApplicationManagementException If an error occurs while retrieving the config.
+     */
     @Override
     public InboundProtocolConfigurationDTO handleConfigRetrieval(String issuer)
             throws IdentityApplicationManagementException {
@@ -135,7 +198,6 @@ public class SAML2InboundAuthConfigHandler implements ApplicationInboundAuthConf
         }
     }
     
-    
     private static SAMLSSOServiceProviderDTO createSAMLSpWithMetadataFile(String encodedMetaFileContent)
             throws IdentitySAML2SSOException {
         
@@ -175,12 +237,12 @@ public class SAML2InboundAuthConfigHandler implements ApplicationInboundAuthConf
             throws IdentitySAML2SSOException {
         
         // First we identify whether this is a insert or update.
-        String currentIssuer = getInboundAuthKey(application, FrameworkConstants.StandardInboundProtocols.SAML2);
+        Optional<String> optionalInboundAuthKey = getInboundAuthKey(application, SAML2);
         InboundAuthenticationRequestConfig updatedInbound;
-        if (currentIssuer != null) {
+        if (optionalInboundAuthKey.isPresent()) {
             // This is an update.
             SAMLSSOServiceProviderDTO samlssoServiceProviderDTO = updateSamlSSoServiceProviderDTO(
-                    saml2ProtocolConfigDTO, currentIssuer);
+                    saml2ProtocolConfigDTO, optionalInboundAuthKey.get());
             
             // Set certificate if available.
             if (samlssoServiceProviderDTO.getCertificateContent() != null) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandler.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandler.java
@@ -1,0 +1,281 @@
+package org.wso2.carbon.identity.sso.saml;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
+import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolConfigurationDTO;
+import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolsDTO;
+import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInboundAuthConfigHandler;
+import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.sso.saml.dto.SAML2ProtocolConfigDTO;
+import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOServiceProviderDTO;
+import org.wso2.carbon.identity.sso.saml.exception.IdentitySAML2ClientException;
+import org.wso2.carbon.identity.sso.saml.exception.IdentitySAML2SSOException;
+import org.wso2.carbon.identity.sso.saml.internal.IdentitySAMLSSOServiceComponentHolder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.StandardInboundProtocols.SAML2;
+import static org.wso2.carbon.identity.application.mgt.inbound.InboundFunctions.getInboundAuthKey;
+
+public class SAML2InboundAuthConfigHandler implements ApplicationInboundAuthConfigHandler {
+    
+    private static final String ATTRIBUTE_CONSUMING_SERVICE_INDEX = "attrConsumServiceIndex";
+    
+    @Override
+    public boolean canHandle(InboundProtocolsDTO inboundProtocolsDTO) {
+        
+        return inboundProtocolsDTO.getInboundProtocolConfigurationMap().containsKey(SAML2);
+    }
+    
+    @Override
+    public boolean canHandle(String protocolName) {
+        
+        return StringUtils.containsIgnoreCase(ApplicationConstants.StandardInboundProtocols.SAML2, protocolName);
+    }
+    
+    @Override
+    public InboundAuthenticationRequestConfig handleConfigCreation(ServiceProvider serviceProvider,
+                                                                   InboundProtocolsDTO inboundProtocolsDTO)
+            throws IdentityApplicationManagementException {
+        
+        SAML2ProtocolConfigDTO saml2ProtocolConfigDTO = getSAML2ProtocolConfigDTO(inboundProtocolsDTO);
+        try {
+            return createSAMLInbound(serviceProvider, saml2ProtocolConfigDTO);
+        } catch (IdentitySAML2ClientException e) {
+            throw new IdentityApplicationManagementClientException(e.getMessage(), e);
+        } catch (IdentitySAML2SSOException e) {
+            throw new IdentityApplicationManagementException(e.getErrorCode(), e.getMessage(), e);
+        }
+    }
+    
+    @Override
+    public InboundAuthenticationRequestConfig handleConfigUpdate(
+            ServiceProvider serviceProvider, InboundProtocolConfigurationDTO inboundProtocolConfigurationDTO)
+            throws IdentityApplicationManagementException {
+        
+        SAML2ProtocolConfigDTO saml2ProtocolConfigDTO = (SAML2ProtocolConfigDTO) inboundProtocolConfigurationDTO;
+        try {
+            return updateSAMLInbound(serviceProvider, saml2ProtocolConfigDTO);
+        } catch (IdentitySAML2ClientException e) {
+            throw new IdentityApplicationManagementClientException(e.getErrorCode(), e.getMessage(), e);
+        } catch (IdentitySAML2SSOException e) {
+            throw new IdentityApplicationManagementException(e.getErrorCode(), e.getMessage(), e);
+        }
+    }
+    
+    @Override
+    public void handleConfigDeletion(String issuer) throws IdentityApplicationManagementException {
+        
+        try {
+            IdentitySAMLSSOServiceComponentHolder.getInstance().getSamlSSOConfigService().removeServiceProvider(issuer,
+                    false);
+        } catch (IdentityException e) {
+            throw new IdentityApplicationManagementException(e.getErrorCode(), e.getMessage(), e);
+        }
+    }
+    
+    @Override
+    public InboundProtocolConfigurationDTO handleConfigRetrieval(String issuer)
+            throws IdentityApplicationManagementException {
+        
+        try {
+            SAML2ProtocolConfigDTO saml2ProtocolConfigDTO = new SAML2ProtocolConfigDTO();
+            SAMLSSOServiceProviderDTO samlSSOServiceProviderDTO = IdentitySAMLSSOServiceComponentHolder.getInstance()
+                    .getSamlSSOConfigService().getServiceProvider(issuer);
+            saml2ProtocolConfigDTO.setManualConfiguration(samlSSOServiceProviderDTO);
+            return saml2ProtocolConfigDTO;
+        } catch (IdentityException e) {
+            throw new IdentityApplicationManagementException(e.getErrorCode(), e.getMessage(), e);
+        }
+    }
+    
+    private static SAML2ProtocolConfigDTO getSAML2ProtocolConfigDTO(InboundProtocolsDTO inboundProtocolsDTO) {
+        
+        InboundProtocolConfigurationDTO inboundProtocolConfigurationDTO = inboundProtocolsDTO
+                .getInboundProtocolConfigurationMap().get(SAML2);
+        return (SAML2ProtocolConfigDTO) inboundProtocolConfigurationDTO;
+    }
+    
+    private InboundAuthenticationRequestConfig createSAMLInbound(ServiceProvider serviceProvider,
+                                                         SAML2ProtocolConfigDTO saml2Configuration)
+            throws IdentitySAML2SSOException {
+        
+        SAMLSSOServiceProviderDTO samlssoServiceProviderDTO = getSamlSsoServiceProviderDTO(saml2Configuration);
+        
+        // Set certificate if available.
+        if (samlssoServiceProviderDTO.getCertificateContent() != null) {
+            serviceProvider.setCertificateContent(base64Encode(samlssoServiceProviderDTO.getCertificateContent()));
+        }
+        
+        return createInboundAuthenticationRequestConfig(samlssoServiceProviderDTO);
+    }
+    
+    private static SAMLSSOServiceProviderDTO getSamlSsoServiceProviderDTO(SAML2ProtocolConfigDTO saml2ProtocolConfigDTO)
+            throws IdentitySAML2SSOException {
+        
+        SAMLSSOServiceProviderDTO samlManualConfiguration = saml2ProtocolConfigDTO.getManualConfiguration();
+        
+        if (saml2ProtocolConfigDTO.getMetadataFile() != null) {
+            return createSAMLSpWithMetadataFile(saml2ProtocolConfigDTO.getMetadataFile());
+        } else if (saml2ProtocolConfigDTO.getMetadataURL() != null) {
+            return createSAMLSpWithMetadataUrl(saml2ProtocolConfigDTO.getMetadataURL());
+        } else if (samlManualConfiguration != null) {
+            return createSAMLSpWithManualConfiguration(samlManualConfiguration);
+        } else {
+            throw new IdentitySAML2ClientException("Invalid SAML2 Configuration. One of metadataFile, metaDataUrl or " +
+                    "serviceProvider manual configuration needs to be present.");
+        }
+    }
+    
+    
+    private static SAMLSSOServiceProviderDTO createSAMLSpWithMetadataFile(String encodedMetaFileContent)
+            throws IdentitySAML2SSOException {
+        
+        byte[] metaData = Base64.getDecoder().decode(encodedMetaFileContent.getBytes(StandardCharsets.UTF_8));
+        String base64DecodedMetadata = new String(metaData, StandardCharsets.UTF_8);
+        
+        return IdentitySAMLSSOServiceComponentHolder.getInstance().getSamlSSOConfigService()
+                .uploadRPServiceProvider(base64DecodedMetadata, false);
+    }
+    
+    private static SAMLSSOServiceProviderDTO createSAMLSpWithMetadataUrl(String metadataUrl)
+            throws IdentitySAML2SSOException {
+        
+        return IdentitySAMLSSOServiceComponentHolder.getInstance().getSamlSSOConfigService()
+                .createServiceProviderWithMetadataURL(metadataUrl, false);
+    }
+    
+    private static SAMLSSOServiceProviderDTO createSAMLSpWithManualConfiguration(
+            SAMLSSOServiceProviderDTO samlssoServiceProviderDTO) throws IdentitySAML2SSOException {
+        
+        try {
+            return IdentitySAMLSSOServiceComponentHolder.getInstance().getSamlSSOConfigService()
+                    .createServiceProvider(samlssoServiceProviderDTO, false);
+        } catch (IdentityException e) {
+            throw handleException("Error while creating SAML2 service provider.", e);
+        }
+    }
+    
+    private static String base64Encode(String content) {
+        
+        return new String(Base64.getEncoder().encode(content.getBytes(StandardCharsets.UTF_8)),
+                (StandardCharsets.UTF_8));
+    }
+    
+    InboundAuthenticationRequestConfig updateSAMLInbound(ServiceProvider application,
+                                                      SAML2ProtocolConfigDTO saml2ProtocolConfigDTO)
+            throws IdentitySAML2SSOException {
+        
+        // First we identify whether this is a insert or update.
+        String currentIssuer = getInboundAuthKey(application, FrameworkConstants.StandardInboundProtocols.SAML2);
+        InboundAuthenticationRequestConfig updatedInbound;
+        if (currentIssuer != null) {
+            // This is an update.
+            SAMLSSOServiceProviderDTO samlssoServiceProviderDTO = updateSamlSSoServiceProviderDTO(
+                    saml2ProtocolConfigDTO, currentIssuer);
+            
+            // Set certificate if available.
+            if (samlssoServiceProviderDTO.getCertificateContent() != null) {
+                application.setCertificateContent(base64Encode(samlssoServiceProviderDTO.getCertificateContent()));
+            }
+            updatedInbound = createInboundAuthenticationRequestConfig(samlssoServiceProviderDTO);
+        } else {
+            updatedInbound = createSAMLInbound(application, saml2ProtocolConfigDTO);
+        }
+        return updatedInbound;
+    }
+    
+    private static SAMLSSOServiceProviderDTO updateSamlSSoServiceProviderDTO(
+            SAML2ProtocolConfigDTO saml2ProtocolConfigDTO, String currentIssuer)
+            throws IdentitySAML2SSOException {
+        
+        SAMLSSOServiceProviderDTO samlManualConfiguration = saml2ProtocolConfigDTO.getManualConfiguration();
+        
+        if (saml2ProtocolConfigDTO.getMetadataFile() != null) {
+            return updateSAMLSpWithMetadataFile(saml2ProtocolConfigDTO.getMetadataFile(), currentIssuer);
+        } else if (saml2ProtocolConfigDTO.getMetadataURL() != null) {
+            return updateSAMLSpWithMetadataUrl(saml2ProtocolConfigDTO.getMetadataURL(), currentIssuer);
+        } else if (samlManualConfiguration != null) {
+            return updateSAMLSpWithManualConfiguration(samlManualConfiguration, currentIssuer);
+        } else {
+            throw new IdentitySAML2ClientException("Invalid SAML2 Configuration. One of metadataFile, metaDataUrl or " +
+                    "serviceProvider manual configuration needs to be present.");
+        }
+    }
+    
+    private static SAMLSSOServiceProviderDTO updateSAMLSpWithMetadataFile(String encodedMetaFileContent,
+                                                                          String currentIssuer)
+            throws IdentitySAML2SSOException {
+        
+        byte[] metaData = Base64.getDecoder().decode(encodedMetaFileContent.getBytes(StandardCharsets.UTF_8));
+        String base64DecodedMetadata = new String(metaData, StandardCharsets.UTF_8);
+        
+        return IdentitySAMLSSOServiceComponentHolder.getInstance().getSamlSSOConfigService()
+                .updateRPServiceProviderWithMetadata(base64DecodedMetadata, currentIssuer, false);
+    }
+    
+    private static SAMLSSOServiceProviderDTO updateSAMLSpWithMetadataUrl(String metadataUrl, String currentIssuer)
+            throws IdentitySAML2SSOException {
+        
+        return IdentitySAMLSSOServiceComponentHolder.getInstance().getSamlSSOConfigService()
+                .updateServiceProviderWithMetadataURL(metadataUrl, currentIssuer, false);
+    }
+    
+    private static SAMLSSOServiceProviderDTO updateSAMLSpWithManualConfiguration(
+            SAMLSSOServiceProviderDTO samlssoServiceProviderDTO, String currentIssuer)
+            throws IdentitySAML2SSOException {
+        try {
+            return IdentitySAMLSSOServiceComponentHolder.getInstance().getSamlSSOConfigService().updateServiceProvider(
+                    samlssoServiceProviderDTO, currentIssuer, false);
+        } catch (IdentityException e) {
+            // The above service always returns exception with error code, error message and cause.
+            throw handleException(e.getMessage(), e);
+        }
+    }
+    
+    private static InboundAuthenticationRequestConfig createInboundAuthenticationRequestConfig(
+            SAMLSSOServiceProviderDTO samlssoServiceProviderDTO) throws IdentitySAML2SSOException {
+        
+        InboundAuthenticationRequestConfig samlInbound = new InboundAuthenticationRequestConfig();
+        samlInbound.setInboundAuthType(FrameworkConstants.StandardInboundProtocols.SAML2);
+        samlInbound.setInboundAuthKey(samlssoServiceProviderDTO.getIssuer());
+        if (samlssoServiceProviderDTO.isEnableAttributeProfile()) {
+            Property[] properties = new Property[1];
+            Property property = new Property();
+            property.setName(ATTRIBUTE_CONSUMING_SERVICE_INDEX);
+            if (StringUtils.isNotBlank(samlssoServiceProviderDTO.getAttributeConsumingServiceIndex())) {
+                property.setValue(samlssoServiceProviderDTO.getAttributeConsumingServiceIndex());
+            } else {
+                try {
+                    property.setValue(Integer.toString(IdentityUtil.getRandomInteger()));
+                } catch (IdentityException e) {
+                    throw handleException(e.getMessage(), e);
+                }
+            }
+            properties[0] = property;
+            samlInbound.setProperties(properties);
+        }
+        samlInbound.setData(samlssoServiceProviderDTO.getAuditLogData());
+        return samlInbound;
+    }
+    
+    private static IdentitySAML2SSOException handleException(String message, IdentityException ex) {
+        
+        if (ex instanceof IdentitySAML2ClientException) {
+            return (IdentitySAML2ClientException) ex;
+        } else if (ex instanceof IdentitySAML2SSOException) {
+            return (IdentitySAML2SSOException) ex;
+        }
+        else {
+            return new IdentitySAML2SSOException(ex.getErrorCode(), message, ex);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConfigServiceImpl.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConfigServiceImpl.java
@@ -194,7 +194,8 @@ public class SAMLSSOConfigServiceImpl {
         return uploadRPServiceProvider(metadata, true);
     }
     
-    SAMLSSOServiceProviderDTO uploadRPServiceProvider(String metadata, boolean enableAuditing) throws IdentitySAML2SSOException {
+    SAMLSSOServiceProviderDTO uploadRPServiceProvider(String metadata, boolean enableAuditing)
+            throws IdentitySAML2SSOException {
         
         try {
             SAMLSSOConfigAdmin configAdmin = new SAMLSSOConfigAdmin(getConfigSystemRegistry(), enableAuditing);

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConfigServiceImpl.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConfigServiceImpl.java
@@ -116,9 +116,14 @@ public class SAMLSSOConfigServiceImpl {
      * @throws IdentityException
      */
     public SAMLSSOServiceProviderDTO createServiceProvider(SAMLSSOServiceProviderDTO spDto) throws IdentityException {
-
+        
+        return createServiceProvider(spDto, true);
+    }
+    
+    SAMLSSOServiceProviderDTO createServiceProvider(SAMLSSOServiceProviderDTO spDto, boolean enableAuditing) throws IdentityException {
+        
         validateSAMLSSOServiceProviderDTO(spDto);
-        SAMLSSOConfigAdmin configAdmin = new SAMLSSOConfigAdmin(getConfigSystemRegistry());
+        SAMLSSOConfigAdmin configAdmin = new SAMLSSOConfigAdmin(getConfigSystemRegistry(), enableAuditing);
         try {
             return configAdmin.addSAMLServiceProvider(spDto);
         } catch (IdentityException ex) {
@@ -137,8 +142,15 @@ public class SAMLSSOConfigServiceImpl {
     public SAMLSSOServiceProviderDTO updateServiceProvider(SAMLSSOServiceProviderDTO serviceProviderDTO, String currentIssuer)
             throws IdentityException {
 
+        return updateServiceProvider(serviceProviderDTO, currentIssuer, true);
+    }
+    
+    SAMLSSOServiceProviderDTO updateServiceProvider(SAMLSSOServiceProviderDTO serviceProviderDTO, String currentIssuer,
+                                                    boolean enableAuditing)
+            throws IdentityException {
+        
         validateSAMLSSOServiceProviderDTO(serviceProviderDTO);
-        SAMLSSOConfigAdmin configAdmin = new SAMLSSOConfigAdmin(getConfigSystemRegistry());
+        SAMLSSOConfigAdmin configAdmin = new SAMLSSOConfigAdmin(getConfigSystemRegistry(), enableAuditing);
         try {
             return configAdmin.updateSAMLServiceProvider(serviceProviderDTO, currentIssuer);
         } catch (IdentityException ex) {
@@ -179,8 +191,13 @@ public class SAMLSSOConfigServiceImpl {
 
     public SAMLSSOServiceProviderDTO uploadRPServiceProvider(String metadata) throws IdentitySAML2SSOException {
 
+        return uploadRPServiceProvider(metadata, true);
+    }
+    
+    SAMLSSOServiceProviderDTO uploadRPServiceProvider(String metadata, boolean enableAuditing) throws IdentitySAML2SSOException {
+        
         try {
-            SAMLSSOConfigAdmin configAdmin = new SAMLSSOConfigAdmin(getConfigSystemRegistry());
+            SAMLSSOConfigAdmin configAdmin = new SAMLSSOConfigAdmin(getConfigSystemRegistry(), enableAuditing);
             if (log.isDebugEnabled()) {
                 log.debug("Creating SAML Service Provider with metadata: " + metadata);
             }
@@ -202,8 +219,15 @@ public class SAMLSSOConfigServiceImpl {
     public SAMLSSOServiceProviderDTO updateRPServiceProviderWithMetadata(String metadata, String currentIssuer)
             throws IdentitySAML2SSOException {
 
+        return updateRPServiceProviderWithMetadata(metadata, currentIssuer, true);
+    }
+    
+    SAMLSSOServiceProviderDTO updateRPServiceProviderWithMetadata(String metadata, String currentIssuer,
+                                                                  boolean enableAuditing)
+            throws IdentitySAML2SSOException {
+        
         try {
-            SAMLSSOConfigAdmin configAdmin = new SAMLSSOConfigAdmin(getConfigSystemRegistry());
+            SAMLSSOConfigAdmin configAdmin = new SAMLSSOConfigAdmin(getConfigSystemRegistry(), enableAuditing);
             if (log.isDebugEnabled()) {
                 log.debug("Updating SAML Service Provider with metadata: " + metadata);
             }
@@ -222,7 +246,13 @@ public class SAMLSSOConfigServiceImpl {
      */
     public SAMLSSOServiceProviderDTO createServiceProviderWithMetadataURL(String metadataUrl)
             throws IdentitySAML2SSOException {
-
+        
+        return createServiceProviderWithMetadataURL(metadataUrl, true);
+    }
+    
+    SAMLSSOServiceProviderDTO createServiceProviderWithMetadataURL(String metadataUrl, boolean enableAuditing)
+            throws IdentitySAML2SSOException {
+        
         try {
             URL url = new URL(metadataUrl);
             URLConnection con = url.openConnection();
@@ -230,7 +260,7 @@ public class SAMLSSOConfigServiceImpl {
             con.setReadTimeout(getReadTimeoutInMillis());
             try (InputStream inputStream = new BoundedInputStream(con.getInputStream(), getMaxSizeInBytes())) {
                 String metadata = IOUtils.toString(inputStream);
-                return uploadRPServiceProvider(metadata);
+                return uploadRPServiceProvider(metadata, enableAuditing);
             }
         } catch (IOException e) {
             throw handleIOException(URL_NOT_FOUND, "Non-existing metadata URL for SAML service provider creation in tenantDomain: "
@@ -249,6 +279,13 @@ public class SAMLSSOConfigServiceImpl {
     public SAMLSSOServiceProviderDTO updateServiceProviderWithMetadataURL(String metadataUrl, String currentIssuer)
             throws IdentitySAML2SSOException {
 
+        return updateServiceProviderWithMetadataURL(metadataUrl, currentIssuer, true);
+    }
+    
+    SAMLSSOServiceProviderDTO updateServiceProviderWithMetadataURL(String metadataUrl, String currentIssuer,
+                                                                   boolean enableAuditing)
+            throws IdentitySAML2SSOException {
+        
         try {
             URL url = new URL(metadataUrl);
             URLConnection connection = url.openConnection();
@@ -256,12 +293,12 @@ public class SAMLSSOConfigServiceImpl {
             connection.setReadTimeout(getReadTimeoutInMillis());
             try (InputStream inputStream = new BoundedInputStream(connection.getInputStream(), getMaxSizeInBytes())) {
                 String metadata = IOUtils.toString(inputStream);
-                return updateRPServiceProviderWithMetadata(metadata, currentIssuer);
+                return updateRPServiceProviderWithMetadata(metadata, currentIssuer, enableAuditing);
             }
         } catch (IOException e) {
             throw handleIOException(URL_NOT_FOUND,
                     "Non-existing metadata URL for SAML service provider creation in tenantDomain: "
-                    + getTenantDomain(), e);
+                            + getTenantDomain(), e);
         }
     }
 
@@ -459,8 +496,13 @@ public class SAMLSSOConfigServiceImpl {
      */
     public boolean removeServiceProvider(String issuer) throws IdentityException {
 
+        return removeServiceProvider(issuer, true);
+    }
+    
+    boolean removeServiceProvider(String issuer, boolean enableAuditing) throws IdentityException {
+        
         try {
-            SAMLSSOConfigAdmin ssoConfigAdmin = new SAMLSSOConfigAdmin(getConfigSystemRegistry());
+            SAMLSSOConfigAdmin ssoConfigAdmin = new SAMLSSOConfigAdmin(getConfigSystemRegistry(), enableAuditing);
             return ssoConfigAdmin.removeServiceProvider(issuer);
         } catch (IdentityException ex) {
             String msg = "Error removing SAML SP with issuer: " + issuer + " in tenantDomain: " + getTenantDomain();
@@ -557,9 +599,12 @@ public class SAMLSSOConfigServiceImpl {
     private IdentitySAML2SSOException handleException(String message, IdentityException ex) {
 
         setErrorCodeIfNotDefined(ex);
-        if (ex instanceof IdentitySAML2SSOException) {
+        if (ex instanceof IdentitySAML2ClientException) {
+            return (IdentitySAML2ClientException) ex;
+        } else if (ex instanceof IdentitySAML2SSOException) {
             return (IdentitySAML2SSOException) ex;
-        } else {
+        }
+        else {
             return new IdentitySAML2SSOException(ex.getErrorCode(), message, ex);
         }
     }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -208,6 +208,7 @@ public class SAMLSSOConstants {
 
         public static final String CREATE_SAML_APPLICATION = "CREATE SAML APPLICATION";
         public static final String DELETE_SAML_APPLICATION = "DELETE SAML APPLICATION";
+        public static final String UPDATE_SAML_APPLICATION = "UPDATE SAML APPLICATION";
         public static final String SAML_INBOUND_SERVICE = "saml-inbound-service";
 
         /**

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
@@ -18,8 +18,6 @@
 
 package org.wso2.carbon.identity.sso.saml.admin;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -28,7 +26,6 @@ import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.SAMLSSOServiceProviderDO;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -48,16 +45,15 @@ import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.AuditLog;
-import org.wso2.carbon.utils.CarbonUtils;
 
 import java.security.KeyStore;
 import java.security.cert.CertificateException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.LogConstants.USER;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.LogConstants.TARGET_APPLICATION;
+import static org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil.isEnableV2AuditLogs;
 import static org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils.triggerAuditLogEvent;
 import static org.wso2.carbon.identity.sso.saml.Error.CONFLICTING_SAML_ISSUER;
 import static org.wso2.carbon.identity.sso.saml.Error.INVALID_REQUEST;
@@ -109,7 +105,7 @@ public class SAMLSSOConfigAdmin {
             }
             boolean isSuccess = IdentitySAMLSSOServiceComponentHolder.getInstance().getSAMLSSOServiceProviderManager()
                     .addServiceProvider(serviceProviderDO, tenantId);
-            if (isSuccess && CarbonUtils.isLegacyAuditLogsDisabled() && enableAuditing) {
+            if (isSuccess && isEnableV2AuditLogs() && enableAuditing) {
                 Optional<String> initiatorId = getInitiatorId();
                 if (initiatorId.isPresent()) {
                     AuditLog.AuditLogBuilder auditLogBuilder = new AuditLog.AuditLogBuilder(
@@ -178,7 +174,7 @@ public class SAMLSSOConfigAdmin {
             SAMLSSOServiceProviderDTO samlssoServiceProviderDTO = persistSAMLServiceProvider(serviceProviderDO);
             Map<String, Object> spDataMap = SAMLSSOUtil.buildSPData(serviceProviderDO);
             samlssoServiceProviderDTO.setAuditLogData(spDataMap);
-            if (CarbonUtils.isLegacyAuditLogsDisabled() && enableAuditing) {
+            if (isEnableV2AuditLogs() && enableAuditing) {
                 Optional<String> initiatorId = getInitiatorId();
                 if (initiatorId.isPresent()) {
                     AuditLog.AuditLogBuilder auditLogBuilder = new AuditLog.AuditLogBuilder(
@@ -256,7 +252,7 @@ public class SAMLSSOConfigAdmin {
         }
         Map<String, Object> spDataMap = SAMLSSOUtil.buildSPData(serviceProviderDO);
         samlssoServiceProviderDTO.setAuditLogData(spDataMap);
-        if (CarbonUtils.isLegacyAuditLogsDisabled() && enableAuditing) {
+        if (isEnableV2AuditLogs() && enableAuditing) {
             Optional<String> initiatorId = getInitiatorId();
             if (initiatorId.isPresent()) {
                 AuditLog.AuditLogBuilder auditLogBuilder = new AuditLog.AuditLogBuilder(
@@ -385,7 +381,7 @@ public class SAMLSSOConfigAdmin {
         SAMLSSOServiceProviderDTO samlssoServiceProviderDTO = persistSAMLServiceProvider(samlssoServiceProviderDO);
         Map<String, Object> spDataMap = SAMLSSOUtil.buildSPData(samlssoServiceProviderDO);
         samlssoServiceProviderDTO.setAuditLogData(spDataMap);
-        if (CarbonUtils.isLegacyAuditLogsDisabled() && enableAuditing) {
+        if (isEnableV2AuditLogs() && enableAuditing) {
             Optional<String> initiatorId = getInitiatorId();
             if (initiatorId.isPresent()) {
                 AuditLog.AuditLogBuilder auditLogBuilder = new AuditLog.AuditLogBuilder(
@@ -436,7 +432,7 @@ public class SAMLSSOConfigAdmin {
         }
         Map<String, Object> spDataMap = SAMLSSOUtil.buildSPData(samlssoServiceProviderDO);
         samlssoServiceProviderDTO.setAuditLogData(spDataMap);
-        if (CarbonUtils.isLegacyAuditLogsDisabled() && enableAuditing) {
+        if (isEnableV2AuditLogs() && enableAuditing) {
             Optional<String> initiatorId = getInitiatorId();
             if (initiatorId.isPresent()) {
                 AuditLog.AuditLogBuilder auditLogBuilder = new AuditLog.AuditLogBuilder(
@@ -735,7 +731,7 @@ public class SAMLSSOConfigAdmin {
             boolean isSuccess = IdentitySAMLSSOServiceComponentHolder.getInstance()
                     .getSAMLSSOServiceProviderManager().removeServiceProvider(issuer, tenantId);
             if (isSuccess) {
-                if (CarbonUtils.isLegacyAuditLogsDisabled() && enableAuditing) {
+                if (isEnableV2AuditLogs() && enableAuditing) {
                     Optional<String> initiatorId = getInitiatorId();
                     if (initiatorId.isPresent()) {
                         AuditLog.AuditLogBuilder auditLogBuilder = new AuditLog.AuditLogBuilder(initiatorId.get(),

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAML2ProtocolConfigDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAML2ProtocolConfigDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAML2ProtocolConfigDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAML2ProtocolConfigDTO.java
@@ -114,7 +114,7 @@ public class SAML2ProtocolConfigDTO implements InboundProtocolConfigurationDTO {
      * @return Protocol name.
      */
     @Override
-    public String getProtocolName() {
+    public String fetchProtocolName() {
         
         return ApplicationConstants.StandardInboundProtocols.SAML2;
     }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAML2ProtocolConfigDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAML2ProtocolConfigDTO.java
@@ -1,0 +1,60 @@
+package org.wso2.carbon.identity.sso.saml.dto;
+
+import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
+import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolConfigurationDTO;
+
+import java.util.Map;
+
+public class SAML2ProtocolConfigDTO implements InboundProtocolConfigurationDTO {
+    
+    private SAMLSSOServiceProviderDTO manualConfiguration;
+    private String metadataFile;
+    private String metadataURL;
+    private Map<String, Object> auditLogData;
+    
+    public SAMLSSOServiceProviderDTO getManualConfiguration() {
+        
+        return manualConfiguration;
+    }
+    
+    public void setManualConfiguration(SAMLSSOServiceProviderDTO manualConfiguration) {
+        
+        this.manualConfiguration = manualConfiguration;
+    }
+    
+    public String getMetadataFile() {
+        
+        return metadataFile;
+    }
+    
+    public void setMetadataFile(String metadataFile) {
+        
+        this.metadataFile = metadataFile;
+    }
+    
+    public String getMetadataURL() {
+        
+        return metadataURL;
+    }
+    
+    public void setMetadataURL(String metadataURL) {
+        
+        this.metadataURL = metadataURL;
+    }
+    
+    public Map<String, Object> getAuditLogData() {
+        
+        return auditLogData;
+    }
+    
+    public void setAuditLogData(Map<String, Object> auditLogData) {
+        
+        this.auditLogData = auditLogData;
+    }
+    
+    @Override
+    public String getProtocolName() {
+        
+        return ApplicationConstants.StandardInboundProtocols.SAML2;
+    }
+}

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAML2ProtocolConfigDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAML2ProtocolConfigDTO.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.sso.saml.dto;
 
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
@@ -5,6 +23,9 @@ import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolConfi
 
 import java.util.Map;
 
+/**
+ * SAML2 Inbound Protocol Configuration DTO.
+ */
 public class SAML2ProtocolConfigDTO implements InboundProtocolConfigurationDTO {
     
     private SAMLSSOServiceProviderDTO manualConfiguration;
@@ -17,41 +38,81 @@ public class SAML2ProtocolConfigDTO implements InboundProtocolConfigurationDTO {
         return manualConfiguration;
     }
     
+    /**
+     * Set manual configuration.
+     *
+     * @param manualConfiguration Manual configuration.
+     */
     public void setManualConfiguration(SAMLSSOServiceProviderDTO manualConfiguration) {
         
         this.manualConfiguration = manualConfiguration;
     }
     
+    /**
+     * Get metadata file.
+     *
+     * @return Metadata file.
+     */
     public String getMetadataFile() {
         
         return metadataFile;
     }
     
+    /**
+     * Set metadata file.
+     *
+     * @param metadataFile Metadata file.
+     */
     public void setMetadataFile(String metadataFile) {
         
         this.metadataFile = metadataFile;
     }
     
+    /**
+     * Get metadata URL.
+     *
+     * @return Metadata URL.
+     */
     public String getMetadataURL() {
         
         return metadataURL;
     }
     
+    /**
+     * Set metadata URL.
+     *
+     * @param metadataURL Metadata URL.
+     */
     public void setMetadataURL(String metadataURL) {
         
         this.metadataURL = metadataURL;
     }
     
+    /**
+     * Get audit log data.
+     *
+     * @return Audit log data.
+     */
     public Map<String, Object> getAuditLogData() {
         
         return auditLogData;
     }
     
+    /**
+     * Set audit log data.
+     *
+     * @param auditLogData Audit log data.
+     */
     public void setAuditLogData(Map<String, Object> auditLogData) {
         
         this.auditLogData = auditLogData;
     }
     
+    /**
+     * Get protocol name.
+     *
+     * @return Protocol name.
+     */
     @Override
     public String getProtocolName() {
         

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
@@ -19,7 +19,6 @@ package org.wso2.carbon.identity.sso.saml.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import org.apache.axis2.databinding.annotation.IgnoreNullElement;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.application.common.model.InboundConfigurationProtocol;
@@ -94,7 +93,6 @@ public class SAMLSSOServiceProviderDTO extends InboundConfigurationProtocol impl
     private boolean samlECP;
     private  String idpEntityIDAlias;
 
-    @IgnoreNullElement
     @XmlTransient
     @JsonIgnore
     private Map<String, Object> auditLogData;

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.sso.saml.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.axis2.databinding.annotation.IgnoreNullElement;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.application.common.model.InboundConfigurationProtocol;
@@ -93,6 +94,7 @@ public class SAMLSSOServiceProviderDTO extends InboundConfigurationProtocol impl
     private boolean samlECP;
     private  String idpEntityIDAlias;
 
+    @IgnoreNullElement
     @XmlTransient
     @JsonIgnore
     private Map<String, Object> auditLogData;

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
@@ -42,7 +42,6 @@ import javax.xml.bind.annotation.XmlTransient;
 @JsonTypeName("samlssoServiceProviderDTO")
 public class SAMLSSOServiceProviderDTO extends InboundConfigurationProtocol implements Serializable {
 
-
     private static final long serialVersionUID = -7633935958583257097L;
 
     private String issuer;

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.application.common.model.InboundConfigurationPro
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 
 import java.io.Serializable;
+import java.util.Map;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -89,6 +90,7 @@ public class SAMLSSOServiceProviderDTO extends InboundConfigurationProtocol impl
     private boolean doValidateSignatureInArtifactResolve;
     private boolean samlECP;
     private  String idpEntityIDAlias;
+    private Map<String, Object> auditLogData;
 
     public void setDoValidateSignatureInArtifactResolve(boolean doValidateSignatureInArtifactResolve) {
 
@@ -510,5 +512,23 @@ public class SAMLSSOServiceProviderDTO extends InboundConfigurationProtocol impl
     public void setIdpEntityIDAlias(String idpEntityIDAlias) {
 
         this.idpEntityIDAlias = idpEntityIDAlias;
+    }
+    
+    /**
+     * Get audit log data.
+     * @return A map of audit log data.
+     */
+    public Map<String, Object> getAuditLogData() {
+        
+        return auditLogData;
+    }
+    
+    /**
+     * Set audit log data.
+     * @param auditLogData A map of audit log data.
+     */
+    public void setAuditLogData(Map<String, Object> auditLogData) {
+        
+        this.auditLogData = auditLogData;
     }
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.identity.sso.saml.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
@@ -25,11 +26,7 @@ import org.wso2.carbon.identity.application.common.util.IdentityApplicationManag
 
 import java.io.Serializable;
 import java.util.Map;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.*;
 
 /**
  * This class is used to store the SAML SSO Service Provider related information.
@@ -90,6 +87,9 @@ public class SAMLSSOServiceProviderDTO extends InboundConfigurationProtocol impl
     private boolean doValidateSignatureInArtifactResolve;
     private boolean samlECP;
     private  String idpEntityIDAlias;
+
+    @XmlTransient
+    @JsonIgnore
     private Map<String, Object> auditLogData;
 
     public void setDoValidateSignatureInArtifactResolve(boolean doValidateSignatureInArtifactResolve) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.sso.saml.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.axis2.databinding.annotation.IgnoreNullElement;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.application.common.model.InboundConfigurationProtocol;
@@ -26,7 +27,12 @@ import org.wso2.carbon.identity.application.common.util.IdentityApplicationManag
 
 import java.io.Serializable;
 import java.util.Map;
-import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 
 /**
  * This class is used to store the SAML SSO Service Provider related information.
@@ -88,6 +94,7 @@ public class SAMLSSOServiceProviderDTO extends InboundConfigurationProtocol impl
     private boolean samlECP;
     private  String idpEntityIDAlias;
 
+    @IgnoreNullElement
     @XmlTransient
     @JsonIgnore
     private Map<String, Object> auditLogData;

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponent.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponent.java
@@ -32,12 +32,14 @@ import org.osgi.service.http.HttpService;
 import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.identity.application.authentication.framework.listener.SessionContextMgtListener;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInboundAuthConfigHandler;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.SAMLSSOServiceProviderManager;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.sso.saml.SAML2InboundAuthConfigHandler;
 import org.wso2.carbon.identity.sso.saml.SAMLInboundSessionContextMgtListener;
 import org.wso2.carbon.identity.sso.saml.SAMLLogoutHandler;
 import org.wso2.carbon.identity.sso.saml.SAMLSSOConfigServiceImpl;
@@ -130,8 +132,14 @@ public class IdentitySAMLSSOServiceComponent {
                 SSOServiceProviderConfigManager.getInstance(), null);
 
         SAMLSSOConfigServiceImpl samlSSOConfigService = new SAMLSSOConfigServiceImpl();
+        IdentitySAMLSSOServiceComponentHolder.getInstance().setSamlSSOConfigService(samlSSOConfigService);
         ServiceRegistration samlSsoConfigServiceRegistration =
                 ctxt.getBundleContext().registerService(SAMLSSOConfigServiceImpl.class, samlSSOConfigService, null);
+        SAML2InboundAuthConfigHandler saml2InboundAuthConfigHandler = new SAML2InboundAuthConfigHandler();
+        IdentitySAMLSSOServiceComponentHolder.getInstance().setSaml2InboundAuthConfigHandler(
+                saml2InboundAuthConfigHandler);
+        ctxt.getBundleContext().registerService(ApplicationInboundAuthConfigHandler.class,
+                saml2InboundAuthConfigHandler, null);
         SAMLSSOUtil.setSamlssoConfigService(samlSSOConfigService);
 
         if (samlSsoConfigServiceRegistration != null) {
@@ -436,29 +444,28 @@ public class IdentitySAMLSSOServiceComponent {
         SAMLSSOUtil.removeExtensionProcessors(extensionProcessor);
     }
 
-    /**
-     * Add dependency to the ApplicationManagementService.
-     */
-    @Reference(
-            name = "identity.application.management.service",
-            service = ApplicationManagementService.class,
-            cardinality = ReferenceCardinality.MANDATORY,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetApplicationManagementService"
-    )
-    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
-
-        if (log.isDebugEnabled()) {
-            log.debug("ApplicationManagementService is available");
-        }
-    }
-
-    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
-
-        if (log.isDebugEnabled()) {
-            log.debug("Unset the ApplicationManagementService");
-        }
-    }
+//    /**
+//     * Add dependency to the ApplicationManagementService.
+//     */
+//    @Reference(
+//            name = "identity.application.management.service",
+//            service = ApplicationManagementService.class,
+//            cardinality = ReferenceCardinality.MANDATORY,
+//            policy = ReferencePolicy.DYNAMIC,
+//            unbind = "unsetApplicationManagementService"
+//    )
+//    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+//
+//        log.debug("ApplicationManagementService is available");
+//        IdentitySAMLSSOServiceComponentHolder.getInstance().setApplicationManagementService(
+//                applicationManagementService);
+//    }
+//
+//    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
+//
+//        log.debug("Unset the ApplicationManagementService");
+//        IdentitySAMLSSOServiceComponentHolder.getInstance().setApplicationManagementService(null);
+//    }
 
 
     @Reference(

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponent.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponent.java
@@ -444,30 +444,6 @@ public class IdentitySAMLSSOServiceComponent {
         SAMLSSOUtil.removeExtensionProcessors(extensionProcessor);
     }
 
-//    /**
-//     * Add dependency to the ApplicationManagementService.
-//     */
-//    @Reference(
-//            name = "identity.application.management.service",
-//            service = ApplicationManagementService.class,
-//            cardinality = ReferenceCardinality.MANDATORY,
-//            policy = ReferencePolicy.DYNAMIC,
-//            unbind = "unsetApplicationManagementService"
-//    )
-//    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
-//
-//        log.debug("ApplicationManagementService is available");
-//        IdentitySAMLSSOServiceComponentHolder.getInstance().setApplicationManagementService(
-//                applicationManagementService);
-//    }
-//
-//    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
-//
-//        log.debug("Unset the ApplicationManagementService");
-//        IdentitySAMLSSOServiceComponentHolder.getInstance().setApplicationManagementService(null);
-//    }
-
-
     @Reference(
             name = "saml.sso.service.provider.manager",
             service = org.wso2.carbon.identity.core.SAMLSSOServiceProviderManager.class,

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponentHolder.java
@@ -65,6 +65,7 @@ public class IdentitySAMLSSOServiceComponentHolder {
     
     /**
      * Get SAMLSSOConfigService.
+     *
      * @return SAMLSSOConfigService.
      */
     public SAMLSSOConfigServiceImpl getSamlSSOConfigService() {
@@ -74,6 +75,7 @@ public class IdentitySAMLSSOServiceComponentHolder {
     
     /**
      * Set SAMLSSOConfigService.
+     *
      * @param samlSSOConfigService SAMLSSOConfigService.
      */
     public void setSamlSSOConfigService(SAMLSSOConfigServiceImpl samlSSOConfigService) {
@@ -81,11 +83,21 @@ public class IdentitySAMLSSOServiceComponentHolder {
         this.samlSSOConfigService = samlSSOConfigService;
     }
     
+    /**
+     * Get SAML2InboundAuthConfigHandler.
+     *
+     * @return SAML2InboundAuthConfigHandler.
+     */
     public SAML2InboundAuthConfigHandler getSaml2InboundAuthConfigHandler() {
         
         return saml2InboundAuthConfigHandler;
     }
     
+    /**
+     * Set SAML2InboundAuthConfigHandler.
+     *
+     * @param saml2InboundAuthConfigHandler SAML2InboundAuthConfigHandler.
+     */
     public void setSaml2InboundAuthConfigHandler(SAML2InboundAuthConfigHandler saml2InboundAuthConfigHandler) {
         
         this.saml2InboundAuthConfigHandler = saml2InboundAuthConfigHandler;

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponentHolder.java
@@ -18,7 +18,10 @@
 
 package org.wso2.carbon.identity.sso.saml.internal;
 
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.SAMLSSOServiceProviderManager;
+import org.wso2.carbon.identity.sso.saml.SAML2InboundAuthConfigHandler;
+import org.wso2.carbon.identity.sso.saml.SAMLSSOConfigServiceImpl;
 
 /**
  * Identity SAML SSO Service Component Holder.
@@ -26,6 +29,8 @@ import org.wso2.carbon.identity.core.SAMLSSOServiceProviderManager;
 public class IdentitySAMLSSOServiceComponentHolder {
 
     private SAMLSSOServiceProviderManager samlSSOServiceProviderManager;
+    private SAMLSSOConfigServiceImpl samlSSOConfigService;
+    private SAML2InboundAuthConfigHandler saml2InboundAuthConfigHandler;
 
     private static final IdentitySAMLSSOServiceComponentHolder instance = new IdentitySAMLSSOServiceComponentHolder();
 
@@ -57,6 +62,32 @@ public class IdentitySAMLSSOServiceComponentHolder {
 
         return samlSSOServiceProviderManager;
     }
-
-
+    
+    /**
+     * Get SAMLSSOConfigService.
+     * @return SAMLSSOConfigService.
+     */
+    public SAMLSSOConfigServiceImpl getSamlSSOConfigService() {
+        
+        return samlSSOConfigService;
+    }
+    
+    /**
+     * Set SAMLSSOConfigService.
+     * @param samlSSOConfigService SAMLSSOConfigService.
+     */
+    public void setSamlSSOConfigService(SAMLSSOConfigServiceImpl samlSSOConfigService) {
+        
+        this.samlSSOConfigService = samlSSOConfigService;
+    }
+    
+    public SAML2InboundAuthConfigHandler getSaml2InboundAuthConfigHandler() {
+        
+        return saml2InboundAuthConfigHandler;
+    }
+    
+    public void setSaml2InboundAuthConfigHandler(SAML2InboundAuthConfigHandler saml2InboundAuthConfigHandler) {
+        
+        this.saml2InboundAuthConfigHandler = saml2InboundAuthConfigHandler;
+    }
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/SAMLApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/SAMLApplicationMgtListener.java
@@ -77,7 +77,6 @@ public class SAMLApplicationMgtListener extends AbstractApplicationMgtListener {
                 .getApplicationExcludingFileBasedSPs(applicationName, tenantDomain);
 
         if (sp != null) {
-            // TODO remove after testing
             if (log.isDebugEnabled()) {
                 log.debug("Initiating the deletion of SAML inbound data associated with service provider: "
                         + applicationName);
@@ -89,10 +88,9 @@ public class SAMLApplicationMgtListener extends AbstractApplicationMgtListener {
                         log.debug("Removing SAML inbound data for issuer: " + issuerToBeDeleted + " associated with " +
                                 "service provider: " + applicationName + " of tenantDomain: " + tenantDomain);
                     }
-                    SAMLSSOUtil.getSAMLSSOConfigService().removeServiceProvider(issuerToBeDeleted);
-                    // TODO remove after testing
-                    SAMLSSOUtil.getSAMLSSOConfigService().getServiceProvider(issuerToBeDeleted);
-                } catch (IdentityException e) {
+                    IdentitySAMLSSOServiceComponentHolder.getInstance().getSaml2InboundAuthConfigHandler()
+                            .handleConfigDeletion(issuerToBeDeleted);
+                } catch (IdentityApplicationManagementException e) {
                     String msg = "Error removing SAML inbound data for issuer: %s associated with " +
                             "service provider: %s of tenantDomain: %s during application delete.";
                     throw new IdentityApplicationManagementException(
@@ -100,7 +98,6 @@ public class SAMLApplicationMgtListener extends AbstractApplicationMgtListener {
                 }
             }
         }
-
         return true;
     }
 
@@ -122,11 +119,13 @@ public class SAMLApplicationMgtListener extends AbstractApplicationMgtListener {
                         "issuer: " + storedSAMLIssuer);
             }
             try {
-                SAMLSSOUtil.getSAMLSSOConfigService().removeServiceProvider(storedSAMLIssuer);
-            } catch (IdentityException e) {
+                IdentitySAMLSSOServiceComponentHolder.getInstance().getSaml2InboundAuthConfigHandler()
+                        .handleConfigDeletion(storedSAMLIssuer);
+            } catch (IdentityApplicationManagementException e) {
                 String msg = "Error removing SAML inbound data for issuer: %s associated with " +
                         "service provider with id: %s during application update.";
-                throw new IdentityApplicationManagementException(String.format(msg, storedSAMLIssuer, appId), e);
+                throw new IdentityApplicationManagementException(e.getErrorCode(), e.getMessage(), String.format(msg,
+                        storedSAMLIssuer, appId), e);
             }
         }
     }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.carbon.identity.sso.saml.util;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import net.shibboleth.utilities.java.support.codec.Base64Support;
 import net.shibboleth.utilities.java.support.security.SecureRandomIdentifierGenerationStrategy;
 import net.shibboleth.utilities.java.support.xml.XMLParserException;
@@ -2636,6 +2638,24 @@ public class SAMLSSOUtil {
             log.debug("Error while getting the user id from the authenticated user.", e);
         }
         return Optional.empty();
+    }
+    
+    /**
+     * Build the JSON object of the SAMLSSOServiceProviderDO and return it as a Map.
+     *
+     * @param app SAMLSSOServiceProviderDO object.
+     * @return Map of <String, Object> of the SAMLSSOServiceProviderDO.
+     */
+    public static Map<String, Object> buildSPData(SAMLSSOServiceProviderDO app) {
+        
+        if (app == null) {
+            return new HashMap<>();
+        }
+        
+        Gson gson = new Gson();
+        String json = gson.toJson(app);
+        return gson.fromJson(json, new TypeToken<Map<String, Object>>() {
+        }.getType());
     }
 
     private static String getSPQualifier(QueryParamDTO[] queryParamDTOs) {

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandlerTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandlerTest.java
@@ -1,0 +1,213 @@
+package org.wso2.carbon.identity.sso.saml;
+
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.engine.AxisConfiguration;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.internal.util.reflection.FieldSetter;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.common.model.InboundAuthenticationConfig;
+import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementServiceImpl;
+import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolsDTO;
+import org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent;
+import org.wso2.carbon.identity.sso.saml.dto.SAML2ProtocolConfigDTO;
+import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOServiceProviderDTO;
+import org.wso2.carbon.identity.sso.saml.internal.IdentitySAMLSSOServiceComponentHolder;
+import org.wso2.carbon.utils.ConfigurationContextService;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@PrepareForTest({IdentitySAMLSSOServiceComponentHolder.class, PrivilegedCarbonContext.class})
+public class SAML2InboundAuthConfigHandlerTest extends PowerMockTestCase {
+    
+    @Mock
+    private ConfigurationContext configurationContext;
+    @Mock
+    private AxisConfiguration axisConfiguration;
+    @Mock
+    private IdentitySAMLSSOServiceComponentHolder samlssoServiceComponentHolder;
+    @Mock
+    private SAMLSSOConfigServiceImpl samlssoConfigService;
+    @InjectMocks
+    private SAML2InboundAuthConfigHandler saml2InboundAuthConfigHandler;
+    @Mock
+    private ServiceProvider application;
+    
+    private static final String ISSUER = "Issuer_01";
+    private static final String APPLICATION_NAME = "dummyApplication";
+    private static final String APPLICATION_RESOURCE_ID = "dummyResourceId";
+    private static final String META_DATA_URL = "https://localhost:9443/identity/metadata/saml2";
+    
+    @BeforeMethod
+    public void setUp() throws Exception {
+        
+        MockitoAnnotations.initMocks(this);
+        System.setProperty("carbon.home",
+                System.getProperty("user.dir") + File.separator + "src" + File.separator + "test"
+                        + File.separator + "resources");
+        
+        initConfigsAndRealm();
+    }
+    
+    @Test
+    public void testCreateInboundSAML2Protocol() throws Exception {
+        
+        mockSAMLSSOServiceComponentHolder();
+        mockServiceProvider(false);
+        
+        InboundProtocolsDTO inboundProtocolsDTO = new InboundProtocolsDTO();
+        SAML2ProtocolConfigDTO saml2ProtocolConfigDTO = new SAML2ProtocolConfigDTO();
+        
+        saml2ProtocolConfigDTO.setMetadataURL(META_DATA_URL);
+        inboundProtocolsDTO.addProtocolConfiguration(saml2ProtocolConfigDTO);
+        
+        SAMLSSOServiceProviderDTO updatedSAMLSSOServiceProviderDTO = new SAMLSSOServiceProviderDTO();
+        updatedSAMLSSOServiceProviderDTO.setAuditLogData(getDummyMap());
+        
+        when(samlssoConfigService.createServiceProviderWithMetadataURL(eq(META_DATA_URL), eq(false)))
+                .thenReturn(updatedSAMLSSOServiceProviderDTO);
+        
+        // We don't need the service provider object for OAuth protocol creation.
+        InboundAuthenticationRequestConfig result = saml2InboundAuthConfigHandler.handleConfigCreation(application,
+                inboundProtocolsDTO);
+        
+        // Verify that the OAuthAdminService is called with the correct parameters.
+        verify(samlssoConfigService, times(0)).createServiceProviderWithMetadataURL(eq(META_DATA_URL));
+        verify(samlssoConfigService, times(1)).createServiceProviderWithMetadataURL(eq(META_DATA_URL), eq(false));
+        
+        // Asserting the audit log data is added to the result.
+        Assert.assertFalse(result.getData().isEmpty());
+        Assert.assertEquals(result.getInboundAuthType(), FrameworkConstants.StandardInboundProtocols.SAML2);
+    }
+    
+    @Test
+    public void testUpdateSAML2Protocol() throws Exception {
+        
+        mockPrivilegeCarbonContext();
+//        mockApplicationManagementService();
+        mockSAMLSSOServiceComponentHolder();
+        mockServiceProvider(true);
+        
+        SAMLSSOServiceProviderDTO samlssoServiceProviderDTO = new SAMLSSOServiceProviderDTO();
+        samlssoServiceProviderDTO.setAuditLogData(getDummyMap());
+        samlssoServiceProviderDTO.setIssuer(ISSUER);
+        
+        // Mock behavior when currentClientId is not null, indicating an existing application.
+        when(samlssoConfigService.updateServiceProviderWithMetadataURL(eq(META_DATA_URL), eq(ISSUER), eq(false)))
+                .thenReturn(samlssoServiceProviderDTO);
+        SAML2ProtocolConfigDTO saml2ProtocolConfigDTO = new SAML2ProtocolConfigDTO();
+        saml2ProtocolConfigDTO.setMetadataURL(META_DATA_URL);
+        saml2InboundAuthConfigHandler.handleConfigUpdate(application, saml2ProtocolConfigDTO);
+        
+        // Verify that SAML service provider is updated without the audit logs.
+        verify(samlssoConfigService, times(1)).updateServiceProviderWithMetadataURL(eq(META_DATA_URL), eq(ISSUER),
+                eq(false));
+        verify(samlssoConfigService, times(0)).updateServiceProviderWithMetadataURL(any(), any(), eq(true));
+    }
+    
+    @Test
+    public void testUpdateSAML2Protocol_CreateNewApplication() throws Exception {
+        
+        mockSAMLSSOServiceComponentHolder();
+        mockServiceProvider(false);
+        
+        SAMLSSOServiceProviderDTO updatedSAMLServiceProvider = new SAMLSSOServiceProviderDTO();
+        updatedSAMLServiceProvider.setIssuer(ISSUER);
+        updatedSAMLServiceProvider.setAuditLogData(getDummyMap());
+        when(samlssoConfigService.createServiceProviderWithMetadataURL(eq(META_DATA_URL), eq(false)))
+                .thenReturn(updatedSAMLServiceProvider);
+        
+        // Mock behavior when currentClientId is null, indicating a new application
+        SAML2ProtocolConfigDTO saml2ProtocolConfigDTO = new SAML2ProtocolConfigDTO();
+        saml2ProtocolConfigDTO.setMetadataURL(META_DATA_URL);
+        
+        InboundAuthenticationRequestConfig result = saml2InboundAuthConfigHandler.handleConfigUpdate(application,
+                saml2ProtocolConfigDTO);
+        
+        // Verify that SAML service provider is updated without the audit logs.
+        verify(samlssoConfigService, times(1)).createServiceProviderWithMetadataURL(eq(META_DATA_URL), eq(false));
+        verify(samlssoConfigService, times(0)).createServiceProviderWithMetadataURL(any(), eq(true));
+        Assert.assertFalse(result.getData().isEmpty());
+    }
+    
+    @Test
+    public void testDeleteSAML2Inbound() throws Exception {
+        
+        mockPrivilegeCarbonContext();
+        mockSAMLSSOServiceComponentHolder();
+        
+        saml2InboundAuthConfigHandler.handleConfigDeletion(ISSUER);
+        
+        // Verify that SAML service provider is deleted without the audit logs.
+        verify(samlssoConfigService, times(1)).removeServiceProvider(eq(ISSUER), eq(false));
+        verify(samlssoConfigService, times(0)).removeServiceProvider(eq(ISSUER), eq(true));
+    }
+    
+    private void initConfigsAndRealm() throws Exception {
+        
+        IdentityCoreServiceComponent identityCoreServiceComponent = new IdentityCoreServiceComponent();
+        ConfigurationContextService configurationContextService = new ConfigurationContextService
+                (configurationContext, null);
+        FieldSetter.setField(identityCoreServiceComponent, identityCoreServiceComponent.getClass().
+                getDeclaredField("configurationContextService"), configurationContextService);
+        when(configurationContext.getAxisConfiguration()).thenReturn(axisConfiguration);
+    }
+    
+    private void mockSAMLSSOServiceComponentHolder() {
+        
+        mockStatic(IdentitySAMLSSOServiceComponentHolder.class);
+        Mockito.when(IdentitySAMLSSOServiceComponentHolder.getInstance()).thenReturn(samlssoServiceComponentHolder);
+        when(samlssoServiceComponentHolder.getSamlSSOConfigService()).thenReturn(samlssoConfigService);
+    }
+    
+    private void mockPrivilegeCarbonContext() {
+        
+        mockStatic(PrivilegedCarbonContext.class);
+        PrivilegedCarbonContext privilegedCarbonContext = mock(PrivilegedCarbonContext.class);
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(privilegedCarbonContext);
+    }
+    
+    private void mockServiceProvider(boolean setInboundAuthConfig) {
+        
+        this.application = new ServiceProvider();
+        application.setApplicationName(APPLICATION_NAME);
+        application.setApplicationResourceId(APPLICATION_RESOURCE_ID);
+        InboundAuthenticationConfig inboundAuthenticationConfig = new InboundAuthenticationConfig();
+        if(setInboundAuthConfig) {
+            InboundAuthenticationRequestConfig inboundAuthConfig = new InboundAuthenticationRequestConfig();
+            inboundAuthConfig.setInboundAuthKey(ISSUER);
+            inboundAuthConfig.setInboundAuthType(FrameworkConstants.StandardInboundProtocols.SAML2);
+            inboundAuthenticationConfig.setInboundAuthenticationRequestConfigs(new InboundAuthenticationRequestConfig[]{
+                    inboundAuthConfig
+            });
+            application.setInboundAuthenticationConfig(inboundAuthenticationConfig);
+        }
+    }
+    
+    private Map<String, Object> getDummyMap() {
+        
+        Map<String, Object> dummyMap = new HashMap<>();
+        dummyMap.put("issuer", ISSUER);
+        return dummyMap;
+    }
+}

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandlerTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandlerTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.sso.saml;
 
 import org.apache.axis2.context.ConfigurationContext;
@@ -17,7 +35,6 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
-import org.wso2.carbon.identity.application.mgt.ApplicationManagementServiceImpl;
 import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolsDTO;
 import org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent;
 import org.wso2.carbon.identity.sso.saml.dto.SAML2ProtocolConfigDTO;
@@ -104,7 +121,6 @@ public class SAML2InboundAuthConfigHandlerTest extends PowerMockTestCase {
     public void testUpdateSAML2Protocol() throws Exception {
         
         mockPrivilegeCarbonContext();
-//        mockApplicationManagementService();
         mockSAMLSSOServiceComponentHolder();
         mockServiceProvider(true);
         

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdminTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdminTest.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.sso.saml.admin;
 
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -37,8 +36,11 @@ import org.wso2.carbon.identity.sso.saml.TestUtils;
 import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOServiceProviderDTO;
 import org.wso2.carbon.identity.sso.saml.exception.IdentitySAML2ClientException;
 import org.wso2.carbon.identity.sso.saml.internal.IdentitySAMLSSOServiceComponentHolder;
+import org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtil;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -46,11 +48,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @PrepareForTest({IdentitySAMLSSOServiceComponentHolder.class, SSOServiceProviderConfigManager.class,
-        SAMLSSOServiceProviderDO.class, Parser.class, UserRegistry.class, SAMLSSOConfigAdmin.class})
+        SAMLSSOServiceProviderDO.class, Parser.class, UserRegistry.class, SAMLSSOConfigAdmin.class, SAMLSSOUtil.class})
 @PowerMockIgnore({"javax.xml.*", "org.xml.*", "org.apache.xerces.*", "org.w3c.dom.*"})
 public class SAMLSSOConfigAdminTest extends PowerMockTestCase {
 
-    @InjectMocks
     private SAMLSSOConfigAdmin samlssoConfigAdmin;
 
     @Mock
@@ -61,7 +62,7 @@ public class SAMLSSOConfigAdminTest extends PowerMockTestCase {
 
     @Mock IdentitySAMLSSOServiceComponentHolder identitySAMLSSOServiceComponentHolder;
 
-    @Mock
+    @Mock(serializable = true)
     SAMLSSOServiceProviderDO samlssoServiceProvDO;
 
     @Mock
@@ -69,10 +70,10 @@ public class SAMLSSOConfigAdminTest extends PowerMockTestCase {
 
     @Mock
     Parser parser;
-
+    
     @BeforeMethod
     public void setUp() throws Exception {
-
+        
         TestUtils.startTenantFlow(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         samlssoConfigAdmin = new SAMLSSOConfigAdmin(userRegistry);
         mockStatic(IdentitySAMLSSOServiceComponentHolder.class);
@@ -152,6 +153,8 @@ public class SAMLSSOConfigAdminTest extends PowerMockTestCase {
     public void testUploadRelyingPartyServiceProvider() throws Exception {
 
         String metadata = "metadata";
+        mockStatic(SAMLSSOUtil.class);
+        when(SAMLSSOUtil.buildSPData(any())).thenReturn(Collections.emptyMap());
         when(samlSSOServiceProviderManager.addServiceProvider(any(SAMLSSOServiceProviderDO.class), anyInt()))
                 .thenReturn(true);
         whenNew(SAMLSSOServiceProviderDO.class).withNoArguments().thenReturn(samlssoServiceProvDO);
@@ -192,6 +195,8 @@ public class SAMLSSOConfigAdminTest extends PowerMockTestCase {
     public void testUpdateRelyingPartyServiceProviderWithMetadata() throws Exception {
 
         String metadata = "metadata";
+        mockStatic(SAMLSSOUtil.class);
+        when(SAMLSSOUtil.buildSPData(any())).thenReturn(Collections.emptyMap());
         when(samlSSOServiceProviderManager.updateServiceProvider(any(SAMLSSOServiceProviderDO.class), anyString(), anyInt()))
                 .thenReturn(true);
         whenNew(SAMLSSOServiceProviderDO.class).withNoArguments().thenReturn(samlssoServiceProvDO);

--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
         <axis2.wso2.version>1.6.1-wso2v38</axis2.wso2.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
-        <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.15.2</com.fasterxml.jackson.version>
 
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,11 @@
                 <artifactId>org.wso2.carbon.identity.sp.metadata.saml2</artifactId>
                 <version>${identity.metadata.saml2.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${com.google.code.gson.version}</version>
+            </dependency>
             <!--test setup-->
             <dependency>
                 <groupId>org.testng</groupId>
@@ -476,6 +481,7 @@
         <axis2.wso2.version>1.6.1-wso2v38</axis2.wso2.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <com.fasterxml.jackson.version>2.15.2</com.fasterxml.jackson.version>
+        <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
 
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -482,6 +482,7 @@
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <com.fasterxml.jackson.version>2.15.2</com.fasterxml.jackson.version>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
+        <com.google.code.gson.osgi.version.range>[2.3.1,3.0.0)</com.google.code.gson.osgi.version.range>
 
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -371,11 +371,11 @@
                 <scope>test</scope>
                 <version>${carbon.identity.organization.management.core.version}</version>
             </dependency>
-<!--            <dependency>-->
-<!--                <groupId>com.google.code.gson</groupId>-->
-<!--                <artifactId>gson</artifactId>-->
-<!--                <version>${com.google.code.gson.version}</version>-->
-<!--            </dependency>-->
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${com.google.code.gson.version}</version>
+            </dependency>
         </dependencies>
 
     </dependencyManagement>
@@ -481,8 +481,8 @@
         <axis2.wso2.version>1.6.1-wso2v40</axis2.wso2.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
-<!--        <com.google.code.gson.version>2.9.0</com.google.code.gson.version>-->
-<!--        <com.google.code.gson.osgi.version.range>[2.3.1,3.0.0)</com.google.code.gson.osgi.version.range>-->
+        <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
+        <com.google.code.gson.osgi.version.range>[2.3.1,3.0.0)</com.google.code.gson.osgi.version.range>
 
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -457,8 +457,8 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
-        <carbon.identity.framework.version>5.25.563</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.25.260, 7.0.0)
+        <carbon.identity.framework.version>7.0.12</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.25.260, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.organization.management.core.version>1.0.0</carbon.identity.organization.management.core.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
         <httpcore.version>4.4.14.wso2v1</httpcore.version>
         <httpcomponents-httpclient.wso2.version>4.5.13.wso2v1</httpcomponents-httpclient.wso2.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
-        <axis2.wso2.version>1.6.1.wso2v38</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1.wso2v12</axis2.wso2.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
         <httpcore.version>4.4.14.wso2v1</httpcore.version>
         <httpcomponents-httpclient.wso2.version>4.5.13.wso2v1</httpcomponents-httpclient.wso2.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
-        <axis2.wso2.version>1.6.1-wso2v38</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1.wso2v12</axis2.wso2.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
         <httpcore.version>4.4.14.wso2v1</httpcore.version>
         <httpcomponents-httpclient.wso2.version>4.5.13.wso2v1</httpcomponents-httpclient.wso2.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
-        <axis2.wso2.version>1.6.1.wso2v12</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1-wso2v40</axis2.wso2.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
         <httpcore.version>4.4.14.wso2v1</httpcore.version>
         <httpcomponents-httpclient.wso2.version>4.5.13.wso2v1</httpcomponents-httpclient.wso2.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
-        <axis2.wso2.version>1.6.1.wso2v12</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1.wso2v38</axis2.wso2.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,7 @@
         <httpcore.version>4.4.14.wso2v1</httpcore.version>
         <httpcomponents-httpclient.wso2.version>4.5.13.wso2v1</httpcomponents-httpclient.wso2.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
-        <axis2.wso2.version>1.6.1.wso2v12</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1-wso2v38</axis2.wso2.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
-        <carbon.identity.framework.version>5.25.507</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.563</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.260, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.organization.management.core.version>1.0.0</carbon.identity.organization.management.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
         <axis2.wso2.version>1.6.1-wso2v38</axis2.wso2.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <com.fasterxml.jackson.version>2.15.2</com.fasterxml.jackson.version>
-        <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
+        <com.google.code.gson.version>2.8.9</com.google.code.gson.version>
         <com.google.code.gson.osgi.version.range>[2.3.1,3.0.0)</com.google.code.gson.osgi.version.range>
 
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -371,11 +371,11 @@
                 <scope>test</scope>
                 <version>${carbon.identity.organization.management.core.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${com.google.code.gson.version}</version>
-            </dependency>
+<!--            <dependency>-->
+<!--                <groupId>com.google.code.gson</groupId>-->
+<!--                <artifactId>gson</artifactId>-->
+<!--                <version>${com.google.code.gson.version}</version>-->
+<!--            </dependency>-->
         </dependencies>
 
     </dependencyManagement>
@@ -481,8 +481,8 @@
         <axis2.wso2.version>1.6.1-wso2v40</axis2.wso2.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
-        <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
-        <com.google.code.gson.osgi.version.range>[2.3.1,3.0.0)</com.google.code.gson.osgi.version.range>
+<!--        <com.google.code.gson.version>2.9.0</com.google.code.gson.version>-->
+<!--        <com.google.code.gson.osgi.version.range>[2.3.1,3.0.0)</com.google.code.gson.osgi.version.range>-->
 
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,11 @@
                 <scope>test</scope>
                 <version>${carbon.identity.organization.management.core.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${com.google.code.gson.version}</version>
+            </dependency>
         </dependencies>
 
     </dependencyManagement>
@@ -473,9 +478,11 @@
         <httpcore.version>4.4.14.wso2v1</httpcore.version>
         <httpcomponents-httpclient.wso2.version>4.5.13.wso2v1</httpcomponents-httpclient.wso2.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
-        <axis2.wso2.version>1.6.1.wso2v12</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1-wso2v38</axis2.wso2.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
+        <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
+        <com.google.code.gson.osgi.version.range>[2.3.1,3.0.0)</com.google.code.gson.osgi.version.range>
 
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>


### PR DESCRIPTION
### Proposed changes in this pull request
- Add a protocol config handler to SAMLSSO to call admin services directly from the framework level

With this PR, we will expose the SAMLSSO services from a protocol handler to directly call SAMLAdmin Services from the framework level without publishing audit logs

### When should this PR be merged
- This PR has to be merged after merging https://github.com/wso2/carbon-identity-framework/pull/5146