### PR TITLE
Convert error log to debug log for returnTo url mismatch

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitLogoutRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/IdPInitLogoutRequestProcessor.java
@@ -171,7 +171,9 @@ public class IdPInitLogoutRequestProcessor implements IdpInitSSOLogoutRequestPro
                 if (StringUtils.isNotBlank(returnTo)) {
                     if (!logoutReqIssuer.getIdpInitSLOReturnToURLList().contains(returnTo) && !logoutReqIssuer
                             .getAssertionConsumerUrlList().contains(returnTo)) {
-                        log.error(SAMLSSOConstants.Notification.INVALID_RETURN_TO_URL);
+                        if (log.isDebugEnabled()) {
+                            log.debug(SAMLSSOConstants.Notification.INVALID_RETURN_TO_URL);
+                        }
                         validationResponseDTO.setValid(false);
                         if (LoggerUtils.isDiagnosticLogsEnabled() && finalizeDiagLogBuilder != null) {
                             finalizeDiagLogBuilder.resultStatus(DiagnosticLog.ResultStatus.FAILED)


### PR DESCRIPTION
Client error Invalid 'returnTo' URL in the request gets logged as server error in SAML SSO flow.

This fix is to convert it to a debug log as it should not be logged as a server error.