### PR TITLE
Bump opensaml version to 3.3.1.wso2v11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -502,7 +502,7 @@
         <commons-lang.version.range>[2.6.0,3.0.0)</commons-lang.version.range>
 
         <opensaml.version>3.3.1</opensaml.version>
-        <opensaml3.wso2.version>3.3.1.wso2v7</opensaml3.wso2.version>
+        <opensaml3.wso2.version>3.3.1.wso2v11</opensaml3.wso2.version>
         <shibboleth.version>7.3.0</shibboleth.version>
         <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
         <axis2.osgi.version.range>[1.6.1.wso2v12, 2.0.0)</axis2.osgi.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request
  - $suject
  - From this PR the below dependencies are upgraded in the opensaml orbit jar
       - apache commons codec version from 1.10 to 1.16
        - esapi.version from 2.4.0.0 to 2.5.3.1
        - org.apache.xml.security.version range