### PR TITLE
Update keystore and truststore extension to PKCS

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.AuditLog;
+import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.security.KeyStore;
 import java.security.cert.CertificateException;
@@ -334,8 +335,7 @@ public class SAMLSSOConfigAdmin {
      */
     private String getKeyStoreName(int tenantId) {
 
-        String ksName = IdentityTenantUtil.getTenantDomain(tenantId).replace(".", "-");
-        return (ksName + ".jks");
+        return KeystoreUtils.getKeyStoreFileLocation(IdentityTenantUtil.getTenantDomain(tenantId));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/X509CredentialImpl.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/X509CredentialImpl.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtil;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -205,9 +206,7 @@ public class X509CredentialImpl implements X509Credential {
 
         try {
             // Derive key store name.
-            String ksName = tenantDomain.trim().replace(".", "-");
-            // Derive JKS name.
-            String jksName = ksName + ".jks";
+            String jksName = KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
             privateKey = (PrivateKey) keyStoreManager.getPrivateKey(jksName, tenantDomain);
             signingCert = (X509Certificate) keyStoreManager.getKeyStore(jksName).getCertificate(tenantDomain);
         // This Exception is thrown from the KeyStoreManager.

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -119,6 +119,7 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -924,8 +925,8 @@ public class SAMLSSOUtil {
      * @return key store file name
      */
     public static String generateKSNameFromDomainName(String tenantDomain) {
-        String ksName = tenantDomain.trim().replace(".", "-");
-        return ksName + ".jks";
+
+        return KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtilTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtilTest.java
@@ -62,6 +62,7 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -84,7 +85,8 @@ import static org.testng.Assert.assertTrue;
  */
 @PrepareForTest({IdentityProviderManager.class, IdentityUtil.class, IdentityApplicationManagementUtil.class,
         KeyStoreManager.class, IdentitySAMLSSOServiceComponentHolder.class, SSOServiceProviderConfigManager.class,
-        IdentityTenantUtil.class, ServiceURLBuilder.class, IdentityConstants.class, FrameworkServiceComponent.class})
+        IdentityTenantUtil.class, ServiceURLBuilder.class, IdentityConstants.class, FrameworkServiceComponent.class,
+        KeystoreUtils.class})
 @PowerMockIgnore({"javax.xml.*", "org.xml.*", "org.w3c.dom.*", "org.apache.xerces.*"})
 public class SAMLSSOUtilTest extends PowerMockTestCase {
 
@@ -133,6 +135,12 @@ public class SAMLSSOUtilTest extends PowerMockTestCase {
     public void setUp() throws Exception {
 
         TestUtils.startTenantFlow(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    private void prepareForGetKeyStorePath() throws Exception {
+        mockStatic(KeystoreUtils.class);
+        when(KeystoreUtils.getKeyStoreFileLocation(TestConstants.WSO2_TENANT_DOMAIN)).thenReturn(TestConstants
+                .WSO2_TENANT_DOMAIN.replace(".", "-") + TestUtils.getFilePath(TestConstants.KEY_STORE_NAME));
     }
 
     private void prepareForGetIssuer() throws Exception {
@@ -412,6 +420,7 @@ public class SAMLSSOUtilTest extends PowerMockTestCase {
     public void testGetX509CredentialImplForTenant() throws Exception {
 
         prepareForGetIssuer();
+        prepareForGetKeyStorePath();
         mockStatic(FrameworkServiceComponent.class);
         when(FrameworkServiceComponent.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantManager()).thenReturn(tenantManager);
@@ -430,6 +439,7 @@ public class SAMLSSOUtilTest extends PowerMockTestCase {
     public void testGetX509CredentialImplException() throws Exception {
 
         prepareForGetIssuer();
+        prepareForGetKeyStorePath();
         when(tenantManager.getTenantId(anyString())).thenReturn(1);
         mockStatic(KeyStoreManager.class);
         when(KeyStoreManager.getInstance(eq(1))).thenReturn(keyStoreManager);

--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,7 @@
     </modules>
 
     <properties>
-        <carbon.kernel.version>4.9.10</carbon.kernel.version>
+        <carbon.kernel.version>4.9.23</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
         <carbon.identity.framework.version>5.25.507</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.260, 7.0.0)


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/18466

Change the keystore and the truststore file type from JKS to PKCS12.