### PR TITLE
Fix returning identityProviderMappedUserRoles in federated user logins in SAML apps

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
@@ -55,6 +55,7 @@ import org.opensaml.saml.saml2.core.impl.SubjectConfirmationDataBuilder;
 import org.opensaml.core.xml.schema.XSString;
 import org.opensaml.core.xml.schema.impl.XSStringBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationContextProperty;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
@@ -342,6 +343,7 @@ public class DefaultSAMLAssertionBuilder implements SAMLAssertionBuilder {
             userAttributeSeparator = claimSeparator;
         }
         claims.remove(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR);
+        claims.remove(FrameworkConstants.IDP_MAPPED_USER_ROLES);
 
         AttributeStatement attStmt = new AttributeStatementBuilder().buildObject();
         Iterator<Map.Entry<String, String>> iterator = claims.entrySet().iterator();

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
     <properties>
         <carbon.kernel.version>4.9.23</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
-        <carbon.identity.framework.version>5.25.507</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.0.40</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.260, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.organization.management.core.version>1.0.0</carbon.identity.organization.management.core.version>


### PR DESCRIPTION
Currently when a federated user logs into a SAML app, identityProviderMappedUserRoles claim is returned. This should not be returned as user attributes.

Related Issue - https://github.com/wso2/product-is/issues/19469