### PR TITLE
Fix mutli-valued claims not separating in the SAML federation flow

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
@@ -22,6 +22,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.joda.time.DateTime;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.core.xml.schema.XSString;
+import org.opensaml.core.xml.schema.impl.XSStringBuilder;
 import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml1.core.NameIdentifier;
 import org.opensaml.saml.saml2.core.Assertion;
@@ -52,10 +54,9 @@ import org.opensaml.saml.saml2.core.impl.NameIDBuilder;
 import org.opensaml.saml.saml2.core.impl.SubjectBuilder;
 import org.opensaml.saml.saml2.core.impl.SubjectConfirmationBuilder;
 import org.opensaml.saml.saml2.core.impl.SubjectConfirmationDataBuilder;
-import org.opensaml.core.xml.schema.XSString;
-import org.opensaml.core.xml.schema.impl.XSStringBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationContextProperty;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
@@ -76,8 +77,6 @@ import java.util.regex.Pattern;
 public class DefaultSAMLAssertionBuilder implements SAMLAssertionBuilder {
 
     private static final Log log = LogFactory.getLog(DefaultSAMLAssertionBuilder.class);
-
-    private String userAttributeSeparator = IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT;
 
     @Override
     public void init() throws IdentityException {
@@ -339,8 +338,15 @@ public class DefaultSAMLAssertionBuilder implements SAMLAssertionBuilder {
     protected AttributeStatement buildAttributeStatement(Map<String, String> claims) {
 
         String claimSeparator = claims.get(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR);
+        String userAttributeSeparator;
         if (StringUtils.isNotBlank(claimSeparator)) {
             userAttributeSeparator = claimSeparator;
+        }  else {
+            // In the SAML outbound authenticator, multivalued attributes are concatenated using the primary user
+            // store's attribute separator. Therefore, to ensure uniformity, the multi-attribute separator from
+            // the primary user store is utilized for separating multivalued attributes when MultiAttributeSeparator
+            // is not available in the claims.
+            userAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
         }
         claims.remove(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR);
         claims.remove(FrameworkConstants.IDP_MAPPED_USER_ROLES);

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
@@ -341,11 +341,13 @@ public class DefaultSAMLAssertionBuilder implements SAMLAssertionBuilder {
         String userAttributeSeparator;
         if (StringUtils.isNotBlank(claimSeparator)) {
             userAttributeSeparator = claimSeparator;
-        }  else {
-            // In the SAML outbound authenticator, multivalued attributes are concatenated using the primary user
-            // store's attribute separator. Therefore, to ensure uniformity, the multi-attribute separator from
-            // the primary user store is utilized for separating multivalued attributes when MultiAttributeSeparator
-            // is not available in the claims.
+        } else {
+            /*
+             * In the SAML outbound authenticator, multivalued attributes are concatenated using the primary user
+             * store's attribute separator. Therefore, to ensure uniformity, the multi-attribute separator from
+             * the primary user store is utilized for separating multivalued attributes when MultiAttributeSeparator
+             * is not available in the claims.
+             */
             userAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
         }
         claims.remove(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR);

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponent.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponent.java
@@ -30,6 +30,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.http.HttpService;
 import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticationService;
 import org.wso2.carbon.identity.application.authentication.framework.listener.SessionContextMgtListener;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInboundAuthConfigHandler;
@@ -61,6 +62,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
 import javax.servlet.Servlet;
 
 /**
@@ -464,5 +466,24 @@ public class IdentitySAMLSSOServiceComponent {
         if (log.isDebugEnabled()) {
             log.debug("SAMLSSOServiceProviderManager unset in to bundle");
         }
+    }
+
+    @Reference(
+            name = "identity.application.authentication.framework",
+            service = ApplicationAuthenticationService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetApplicationAuthenticationService"
+    )
+    protected void setApplicationAuthenticationService(
+            ApplicationAuthenticationService applicationAuthenticationService) {
+        /* reference ApplicationAuthenticationService service to guarantee that this component will wait until
+        authentication framework is started */
+    }
+
+    protected void unsetApplicationAuthenticationService(
+            ApplicationAuthenticationService applicationAuthenticationService) {
+        /* reference ApplicationAuthenticationService service to guarantee that this component will wait until
+        authentication framework is started */
     }
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponent.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/internal/IdentitySAMLSSOServiceComponent.java
@@ -477,13 +477,13 @@ public class IdentitySAMLSSOServiceComponent {
     )
     protected void setApplicationAuthenticationService(
             ApplicationAuthenticationService applicationAuthenticationService) {
-        /* reference ApplicationAuthenticationService service to guarantee that this component will wait until
-        authentication framework is started */
+        /* Reference ApplicationAuthenticationService service to guarantee that this component will wait until
+        authentication framework is started. */
     }
 
     protected void unsetApplicationAuthenticationService(
             ApplicationAuthenticationService applicationAuthenticationService) {
-        /* reference ApplicationAuthenticationService service to guarantee that this component will wait until
-        authentication framework is started */
+        /* Reference ApplicationAuthenticationService service to guarantee that this component will wait until
+        authentication framework is started. */
     }
 }

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/util/AssertionBuildingTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/util/AssertionBuildingTest.java
@@ -34,10 +34,12 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockObjectFactory;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.IObjectFactory;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.core.util.KeyStoreManager;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.Property;
@@ -81,11 +83,13 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT;
+
 /**
  * Tests Assertion building functionality.
  */
 @PrepareForTest({IdentityUtil.class, IdentityTenantUtil.class, IdentityProviderManager.class,
-        SSOServiceProviderConfigManager.class, IdentitySAMLSSOServiceComponentHolder.class})
+        SSOServiceProviderConfigManager.class, IdentitySAMLSSOServiceComponentHolder.class, FrameworkUtils.class})
 @WithCarbonHome
 @PowerMockIgnore({"javax.net.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*",
         "javax.security.*", "org.mockito.*"})
@@ -125,6 +129,13 @@ public class AssertionBuildingTest extends PowerMockTestCase {
 
     @Mock
     private X509Credential x509Credential;
+
+    @BeforeMethod
+    public void setUpBeforeMethod() throws Exception {
+
+        mockStatic(FrameworkUtils.class);
+        when(FrameworkUtils.getMultiAttributeSeparator()).thenReturn(MULTI_ATTRIBUTE_SEPARATOR_DEFAULT);
+    }
 
     @Test
     public void testBuildAssertion() throws Exception {


### PR DESCRIPTION
In the SAML outbound authenticator, the concatenation of multivalued attributes relies on the attribute separator configured in the primary user store. To ensures consistency, multi-attribute separator from the primary user store is employed to separate multivalued attributes here when the MultiAttributeSeparator is absent in the claims.

Important:
This fix is a workaround and the issue for a proper fix is tracked here 
- https://github.com/wso2/product-is/issues/20025

### Related Issues
- https://github.com/wso2/product-is/issues/19745