### PR TITLE
Introduce config to send unsplitted SAML multi valued attributes

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -70,6 +70,7 @@ public class SAMLSSOConstants {
     public static final String SAML_SP_CERTIFICATE_EXPIRY_VALIDATION_ENABLED = "SSOService.SAMLSPCertificateExpiryValidationEnable";
     public static final String SAML_IDP_INIT_LOGOUT_RESPONSE_SIGNING_ENABLED = "SSOService.SAMLIdpInitLogoutResponseSigningEnabled";
     public static final String SAML_ASSERTION_ENCRYPT_WITH_APP_CERT = "SSOService.SAMLAssertionEncyptWithAppCert";
+    public static final String SEPARATE_MULTI_ATTRS_FROM_IDPS_USING_ATTRIBUTE_SEPARATOR = "SSOService.SeparateMultiAttributesFromIdP";
     public static final String START_SOAP_BINDING = "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
             "<SOAP-ENV:Body>";
     public static final String END_SOAP_BINDING = "</SOAP-ENV:Body>" +

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
@@ -340,15 +340,23 @@ public class DefaultSAMLAssertionBuilder implements SAMLAssertionBuilder {
         String claimSeparator = claims.get(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR);
         String userAttributeSeparator;
         if (StringUtils.isNotBlank(claimSeparator)) {
+            /*
+            If there are any sp requested claims, then the multi attribute separator claim will be available.
+             */
             userAttributeSeparator = claimSeparator;
         } else {
-            /*
-             * In the SAML outbound authenticator, multivalued attributes are concatenated using the primary user
-             * store's attribute separator. Therefore, to ensure uniformity, the multi-attribute separator from
-             * the primary user store is utilized for separating multivalued attributes when MultiAttributeSeparator
-             * is not available in the claims.
-             */
-            userAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
+            if (!SAMLSSOUtil.separateMultiAttributesFromIdPEnabled()) {
+                userAttributeSeparator = IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT;
+            } else {
+                /*
+                 * In the SAML outbound authenticator, multivalued attributes are concatenated using the primary user
+                 * store's attribute separator. Therefore, to ensure uniformity, the multi-attribute separator from
+                 * the primary user store is utilized for separating multivalued attributes when MultiAttributeSeparator
+                 * is not available in the claims.
+                 */
+                userAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
+            }
+
         }
         claims.remove(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR);
         claims.remove(FrameworkConstants.IDP_MAPPED_USER_ROLES);

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -2756,4 +2756,23 @@ public class SAMLSSOUtil {
         return Boolean.parseBoolean(IdentityUtil.getProperty(
                 SAMLSSOConstants.SAML_IDP_INIT_LOGOUT_RESPONSE_SIGNING_ENABLED));
     }
+
+    /**
+     * SeparateMultiAttributesFromIdP config is used to separate the multi-valued attributes sent from the IdPs.
+     * This config is used when the SP doesn't request any claim in IS, and all the claims from the IdP are passed
+     * to the SP.
+     *
+     * @return false if 'separateMultiAttributesFromIdP' config is disabled. By default, this config is enabled in the
+     * product.
+     */
+    public static boolean separateMultiAttributesFromIdPEnabled() {
+
+        String separateMultiAttributesFromIdPEnabledConfig = IdentityUtil.getProperty(
+                SAMLSSOConstants.SEPARATE_MULTI_ATTRS_FROM_IDPS_USING_ATTRIBUTE_SEPARATOR);
+        if (StringUtils.isNotEmpty(separateMultiAttributesFromIdPEnabledConfig)) {
+            return Boolean.parseBoolean(separateMultiAttributesFromIdPEnabledConfig);
+        } else {
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/20484

We will preserve the new behaviour(splitting the multi valued SAML attributes), and introduce a config to switch to the old behaviour(unsplitted saml multi valued attributes)


```
[saml]
separate_multi_attributes_from_idp = false.
```

If the app wants to get  the unsplitted SAML multi valued attributes, then can enable above config

Refer https://github.com/wso2/product-is/issues/19745 to check the old behaviour