### PR TITLE
Throw client error instead of server error for invalid SAML request decoding issue

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -503,8 +503,8 @@ public class SAMLSSOUtil {
                 byte[] xmlMessageBytes = new byte[5000];
                 int resultLength = inflater.inflate(xmlMessageBytes);
 
-                if (!inflater.finished() ){
-                    throw new RuntimeException("End of the compressed data stream has NOT been reached");
+                if (!inflater.finished()) {
+                    throw new IdentitySAML2ClientException("End of the compressed data stream has NOT been reached.");
                 }
 
                 inflater.end();


### PR DESCRIPTION
Malformed SAML request fails to parse the decoding process, which needs to be handled as client errors instead of runtime errors.