### PR TITLE
Restrict sub organization apps with SAML2 inbound protocol

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -161,6 +161,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
 
         <!--SAML Common Util dependency-->
         <dependency>
@@ -328,11 +332,6 @@
             <artifactId>org.wso2.carbon.identity.testutil</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
-            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -368,6 +367,8 @@
                             org.wso2.carbon.idp.mgt; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.common;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.util;
+                            version="${org.wso2.carbon.identity.organization.management.core.version.range}",
                             org.wso2.carbon.identity.application.mgt.listener;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.apache.xerces.impl; resolution:= optional,

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandler.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAML2InboundAuthConfigHandler.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.sso.saml;
 
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
@@ -30,7 +31,10 @@ import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolConfi
 import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolsDTO;
 import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInboundAuthConfigHandler;
 import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.identity.sso.saml.dto.SAML2ProtocolConfigDTO;
 import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOServiceProviderDTO;
 import org.wso2.carbon.identity.sso.saml.exception.IdentitySAML2ClientException;
@@ -60,7 +64,15 @@ public class SAML2InboundAuthConfigHandler implements ApplicationInboundAuthConf
      */
     @Override
     public boolean canHandle(InboundProtocolsDTO inboundProtocolsDTO) {
-        
+
+        try {
+            String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            if (OrganizationManagementUtil.isOrganization(tenantDomain)) {
+                return false;
+            }
+        } catch (OrganizationManagementException e) {
+            throw new IdentityRuntimeException("Error while checking the tenant domain.", e);
+        }
         return inboundProtocolsDTO.getInboundProtocolConfigurationMap().containsKey(SAML2);
     }
     

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/resources/testng.xml
@@ -20,6 +20,7 @@
 <suite name="identity-sso-saml-test-suite">
     <test name="identity-sso-saml-test-all">
         <classes>
+            <class name="org.wso2.carbon.identity.sso.saml.SAML2InboundAuthConfigHandlerTest"/>
             <class name="org.wso2.carbon.identity.sso.saml.util.AssertionBuildingTest" />
             <class name="org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtilTest" />
             <class name="org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtilMarshallTest" />

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
                 <artifactId>opensaml</artifactId>
                 <version>${opensaml3.wso2.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${carbon.identity.organization.management.core.version}</version>
+            </dependency>
 
             <!--OpenSAML3 dependencies-->
             <dependency>
@@ -366,12 +371,6 @@
                 <version>${xercesImpl.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
-                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
-                <scope>test</scope>
-                <version>${carbon.identity.organization.management.core.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${com.google.code.gson.version}</version>
@@ -484,7 +483,9 @@
         <carbon.identity.framework.version>7.0.105</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.260, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
-        <carbon.identity.organization.management.core.version>1.0.0</carbon.identity.organization.management.core.version>
+        <carbon.identity.organization.management.core.version>1.1.19</carbon.identity.organization.management.core.version>
+        <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
+        </org.wso2.carbon.identity.organization.management.core.version.range>
 
         <identity.inbound.auth.saml.version>${project.version}</identity.inbound.auth.saml.version>
         <identity.inbound.auth.saml.exp.version>${identity.inbound.auth.saml.version}


### PR DESCRIPTION
## Changes in this PR
- $subject
- Part of the fix for : https://github.com/wso2/product-is/issues/21208
- The sub organization applications can only be created with OAuth2 inbound protocol in this phase. This is to impose the restriction for SAML2 app creation for sub organization applications.