### PR TITLE
Remove the usages of deprecated KeyStoreAdmin constructor

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConfigServiceImpl.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConfigServiceImpl.java
@@ -396,7 +396,7 @@ public class SAMLSSOConfigServiceImpl {
     private KeyStoreData[] getKeyStores(int tenantId) throws IdentityException {
 
         try {
-            KeyStoreAdmin admin = new KeyStoreAdmin(tenantId, getGovernanceRegistry());
+            KeyStoreAdmin admin = new KeyStoreAdmin(tenantId);
             return admin.getKeyStores(isSuperTenant(tenantId));
         } catch (SecurityConfigException e) {
             throw new IdentityException("Error when loading the key stores from registry", e);
@@ -561,8 +561,7 @@ public class SAMLSSOConfigServiceImpl {
 
         KeyStoreAdmin admin;
         try {
-            admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId(),
-                    getGovernanceRegistry());
+            admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId());
             return admin.getStoreEntries(keyStoreName);
         } catch (SecurityConfigException e) {
             String message = "Error reading entries from the key store: " + keyStoreName;
@@ -590,11 +589,6 @@ public class SAMLSSOConfigServiceImpl {
 
         return (Registry) PrivilegedCarbonContext.getThreadLocalCarbonContext()
                 .getRegistry(RegistryType.SYSTEM_CONFIGURATION);
-    }
-
-    private Registry getGovernanceRegistry() {
-
-        return (Registry) CarbonContext.getThreadLocalCarbonContext().getRegistry(RegistryType.USER_GOVERNANCE);
     }
 
     private IdentitySAML2SSOException handleException(String message, IdentityException ex) {

--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
     <properties>
         <carbon.kernel.version>4.10.37</carbon.kernel.version>
         <carbon.kernel.feature.version>4.10.37</carbon.kernel.feature.version>
-        <carbon.identity.framework.version>7.7.210</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.269</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.260, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.organization.management.core.version>1.1.19</carbon.identity.organization.management.core.version>


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

Part of: https://github.com/wso2/product-is/issues/21206
Related PR: https://github.com/wso2/carbon-identity-framework/pull/6525