### PR TITLE
Resolve proper tenant domain during front channel SLO with post binding for request signature

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/pom.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/pom.xml
@@ -482,18 +482,21 @@
                         ${argLine}
                         --add-opens=java.base/java.lang=ALL-UNNAMED
                         --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
                         --add-opens=java.base/java.util=ALL-UNNAMED
                         --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
                         --add-opens=java.base/java.util.zip=ALL-UNNAMED
                         --add-opens=java.base/java.util.random=ALL-UNNAMED
                         --add-opens=java.base/java.security=ALL-UNNAMED
                         --add-opens=java.base/java.io=ALL-UNNAMED
+                        --add-opens java.base/java.nio.charset=ALL-UNNAMED
                         --add-opens=java.base/java.security.cert=ALL-UNNAMED
                         --add-opens=java.base/java.util.regex=ALL-UNNAMED
                         --add-opens=java.base/jdk.internal.util=ALL-UNNAMED
                         --add-opens=java.base/jdk.internal.util.random=ALL-UNNAMED
                         --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED
                         --add-opens=java.base/jdk.internal.access=ALL-UNNAMED
+                        --add-opens java.base/sun.nio.cs=ALL-UNNAMED
                         --add-opens=java.base/sun.nio.fs=ALL-UNNAMED
                         --add-opens=java.base/sun.security.util=ALL-UNNAMED
                         --add-opens=java.base/sun.security.jca=ALL-UNNAMED

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -125,6 +125,8 @@ public class SAMLSSOConstants {
 
     public static final String IS_POST = "isPost";
 
+    public static final String SAML_SLO_LOGOUT_REQUEST_SIGNATURE_TENANT_CERT = "SSOService.SAMLSLOLogoutRequestSignatureWithTenantCert";
+
     private SAMLSSOConstants() {
     }
 

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -126,7 +126,7 @@ public class SAMLSSOConstants {
     public static final String IS_POST = "isPost";
 
     public static final String SAML_SLO_FRONT_CHANNEL_POST_BINDING_LOGOUT_REQ_SIG_TENANT_CERT =
-            "SSOService.SAMLSLOLogoutRequestSignatureWithTenantCert";
+            "SSOService.SAMLSLOFrontChannelPostBindingLogoutRequestSignatureWithTenantCert";
 
     private SAMLSSOConstants() {
     }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLSSOConstants.java
@@ -125,7 +125,8 @@ public class SAMLSSOConstants {
 
     public static final String IS_POST = "isPost";
 
-    public static final String SAML_SLO_LOGOUT_REQUEST_SIGNATURE_TENANT_CERT = "SSOService.SAMLSLOLogoutRequestSignatureWithTenantCert";
+    public static final String SAML_SLO_FRONT_CHANNEL_POST_BINDING_LOGOUT_REQ_SIG_TENANT_CERT =
+            "SSOService.SAMLSLOLogoutRequestSignatureWithTenantCert";
 
     private SAMLSSOConstants() {
     }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -2055,6 +2055,9 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                 PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
                 carbonContext.setTenantDomain(tenantDomain);
                 carbonContext.setTenantId(IdentityTenantUtil.getTenantId(tenantDomain));
+
+                logoutRequest = SAMLSSOUtil.setSignature(logoutRequest, samlssoServiceProviderDO.getSigningAlgorithmUri(),
+                        samlssoServiceProviderDO.getDigestAlgorithmUri(), new SignKeyDataHolder(null));
             } finally {
                 PrivilegedCarbonContext.endTenantFlow();
             }

--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -2042,7 +2042,7 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                                  SAMLSSOServiceProviderDO samlssoServiceProviderDO, LogoutRequest logoutRequest)
             throws IdentityException, IOException, ServletException {
 
-        if (!isLogoutRequestSignatureWithTenantCertEnabled()) {
+        if (!useTenantCertForFcPostBindingSloSignature()) {
             // Use default signature (super tenant or null key).
             logoutRequest = SAMLSSOUtil.setSignature(logoutRequest, samlssoServiceProviderDO.getSigningAlgorithmUri(),
                     samlssoServiceProviderDO.getDigestAlgorithmUri(), new SignKeyDataHolder(null));
@@ -2056,7 +2056,8 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                 carbonContext.setTenantDomain(tenantDomain);
                 carbonContext.setTenantId(IdentityTenantUtil.getTenantId(tenantDomain));
 
-                logoutRequest = SAMLSSOUtil.setSignature(logoutRequest, samlssoServiceProviderDO.getSigningAlgorithmUri(),
+                logoutRequest = SAMLSSOUtil.setSignature(logoutRequest,
+                        samlssoServiceProviderDO.getSigningAlgorithmUri(),
                         samlssoServiceProviderDO.getDigestAlgorithmUri(), new SignKeyDataHolder(null));
             } finally {
                 PrivilegedCarbonContext.endTenantFlow();
@@ -2070,13 +2071,15 @@ public class SAMLSSOProviderServlet extends HttpServlet {
     }
 
     /**
-     * Checks if the SAML SLO LogoutRequest should use the tenant's certificate.
+     * Determines whether the SAML SLO LogoutRequest signature for front-channel POST binding
+     * should be generated using the tenant's certificate.
      *
-     * @return true if enabled; false if disabled or property is not set.
+     * @return {@code true} if enabled; {@code false} if disabled or the property is not set.
      */
-    private boolean isLogoutRequestSignatureWithTenantCertEnabled() {
+    private boolean useTenantCertForFcPostBindingSloSignature() {
 
-        String propertyValue = IdentityUtil.getProperty(SAMLSSOConstants.SAML_SLO_LOGOUT_REQUEST_SIGNATURE_TENANT_CERT);
+        String propertyValue = IdentityUtil.getProperty(
+                SAMLSSOConstants.SAML_SLO_FRONT_CHANNEL_POST_BINDING_LOGOUT_REQ_SIG_TENANT_CERT);
 
         return Boolean.parseBoolean(propertyValue);
     }

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServletSendPostRequestTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServletSendPostRequestTest.java
@@ -1,0 +1,146 @@
+package org.wso2.carbon.identity.sso.saml.servlet;
+
+import org.opensaml.saml.saml2.core.LogoutRequest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.model.SAMLSSOServiceProviderDO;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.sso.saml.SAMLSSOConstants;
+import org.wso2.carbon.identity.sso.saml.builders.SignKeyDataHolder;
+import org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtil;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@PrepareForTest({
+        SAMLSSOProviderServlet.class,
+        SAMLSSOUtil.class,
+        PrivilegedCarbonContext.class,
+        IdentityUtil.class,
+        IdentityTenantUtil.class,
+        SignKeyDataHolder.class
+})
+public class SAMLSSOProviderServletSendPostRequestTest extends PowerMockTestCase {
+
+    @DataProvider(name = "tenantFlowScenarios")
+    public Object[][] tenantFlowScenarios() {
+        return new Object[][]{
+                // configEnabled, threadLocalTenant, spTenantDomain, expectedTenantDomain, expectedTenantId
+                {true, null, "tenant1.com", "tenant1.com", 12},                             // normal tenant
+                {true, null, null, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, MultitenantConstants.SUPER_TENANT_ID}, // SP domain null → super tenant
+                {true, "thread-local-tenant", "tenant1.com", "thread-local-tenant", 12},    // thread-local overrides SP
+                {true, "", "tenant1.com", "tenant1.com", 12},                               // empty thread-local → SP domain
+                {true, "", null, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, MultitenantConstants.SUPER_TENANT_ID}, // empty thread-local + SP null → super tenant
+                {false, null, "tenant1.com", MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, MultitenantConstants.SUPER_TENANT_ID}, // config disabled → always super tenant
+                {false, "thread-local-tenant", "tenant1.com", MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, MultitenantConstants.SUPER_TENANT_ID}, // config disabled, thread-local ignored
+        };
+    }
+
+    @Test(dataProvider = "tenantFlowScenarios")
+    public void testSendPostRequestTenantFlow(boolean configEnabled, String threadLocalTenant,
+                                              String spTenantDomain, String expectedTenantDomain,
+                                              int expectedTenantId) throws Exception {
+
+        // --- Mock static methods ---
+        PowerMockito.mockStatic(IdentityTenantUtil.class);
+        PowerMockito.mockStatic(IdentityUtil.class);
+        PowerMockito.mockStatic(SAMLSSOUtil.class);
+        PowerMockito.mockStatic(PrivilegedCarbonContext.class);
+
+        // --- Mock IdentityUtil property ---
+        when(IdentityUtil.getProperty(SAMLSSOConstants.SAML_SLO_FRONT_CHANNEL_POST_BINDING_LOGOUT_REQ_SIG_TENANT_CERT))
+                .thenReturn(Boolean.toString(configEnabled));
+
+        // --- Mock tenant ID resolution ---
+        when(IdentityTenantUtil.getTenantId(anyString())).thenAnswer(invocation -> {
+            String domain = invocation.getArgument(0);
+            if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(domain)) {
+                return MultitenantConstants.SUPER_TENANT_ID;
+            }
+            return 12; // dummy tenant ID for other tenants
+        });
+
+        // --- Mock CarbonContext ---
+        PrivilegedCarbonContext mockContext = mock(PrivilegedCarbonContext.class);
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(mockContext);
+        PowerMockito.doNothing().when(PrivilegedCarbonContext.class, "startTenantFlow");
+        PowerMockito.doNothing().when(PrivilegedCarbonContext.class, "endTenantFlow");
+        doNothing().when(mockContext).setTenantDomain(anyString());
+        doNothing().when(mockContext).setTenantId(anyInt());
+
+        // --- Mock ServiceProviderDO ---
+        SAMLSSOServiceProviderDO spDO = mock(SAMLSSOServiceProviderDO.class);
+        when(spDO.getTenantDomain()).thenReturn(spTenantDomain);
+        when(spDO.getSigningAlgorithmUri()).thenReturn("RSA_SHA256");
+        when(spDO.getDigestAlgorithmUri()).thenReturn("SHA256");
+
+        // --- Mock LogoutRequest ---
+        LogoutRequest logoutRequest = mock(LogoutRequest.class);
+        when(logoutRequest.getDestination()).thenReturn("https://localhost:9443/samlsso");
+
+        // --- Mock SignKeyDataHolder to avoid real keystore access ---
+        SignKeyDataHolder mockCredential = mock(SignKeyDataHolder.class);
+        PowerMockito.whenNew(SignKeyDataHolder.class).withAnyArguments().thenReturn(mockCredential);
+
+        // --- Mock SAMLSSOUtil.setSignature to return input LogoutRequest ---
+        PowerMockito.when(SAMLSSOUtil.setSignature(any(LogoutRequest.class), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // --- Mock thread-local tenant domain if provided ---
+        when(SAMLSSOUtil.getTenantDomainFromThreadLocal()).thenReturn(threadLocalTenant);
+
+        // --- Mock HttpServletResponse with PrintWriter ---
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+        when(resp.getWriter()).thenReturn(printWriter);
+
+        // --- Spy servlet to mock resolveAppName ---
+        SAMLSSOProviderServlet spyServlet = PowerMockito.spy(new SAMLSSOProviderServlet());
+        PowerMockito.doReturn("TestSP").when(spyServlet, "resolveAppName");
+
+        // --- Invoke private sendPostRequest using reflection ---
+        Method method = SAMLSSOProviderServlet.class.getDeclaredMethod(
+                "sendPostRequest",
+                HttpServletRequest.class,
+                HttpServletResponse.class,
+                SAMLSSOServiceProviderDO.class,
+                LogoutRequest.class
+        );
+        method.setAccessible(true);
+        method.invoke(spyServlet, mock(HttpServletRequest.class), resp, spDO, logoutRequest);
+
+        // --- Verify tenant domain and ID set correctly ---
+        if (configEnabled) {
+            verify(mockContext, atLeastOnce()).setTenantDomain(expectedTenantDomain);
+            verify(mockContext, atLeastOnce()).setTenantId(expectedTenantId);
+        } else {
+            // Config disabled → tenant flow skipped, default super tenant used
+            verify(mockContext, never()).setTenantDomain(anyString());
+            verify(mockContext, never()).setTenantId(anyInt());
+        }
+
+        // --- Verify output generated ---
+        String output = stringWriter.toString();
+        assert output.contains("TestSP");
+    }
+}

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServletSendPostRequestTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServletSendPostRequestTest.java
@@ -21,15 +21,15 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 
 @PrepareForTest({
         SAMLSSOProviderServlet.class,

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/resources/testng.xml
@@ -20,6 +20,7 @@
 <suite name="identity-sso-saml-test-suite">
     <test name="identity-sso-saml-test-all">
         <classes>
+            <class name="org.wso2.carbon.identity.sso.saml.servlet.SAMLSSOProviderServletSendPostRequestTest" />
             <class name="org.wso2.carbon.identity.sso.saml.SAML2InboundAuthConfigHandlerTest"/>
             <class name="org.wso2.carbon.identity.sso.saml.util.AssertionBuildingTest" />
             <class name="org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtilTest" />


### PR DESCRIPTION
## Purpose
Currently, when front-channel Single Logout (SLO) is configured with front channel POST binding in a federated flow within a tenant, the certificate included in the LogoutRequest (for the application where the logout is received) is from the super tenant. This occurs because the tenant domain is not properly resolved. Ideally, the correct tenant domain should be identified, and the corresponding tenant-specific certificate should be included in the request.

To enable this fix, add the following config to deployment.toml

```
[saml.slo]
logout_request_signature_with_tenant_cert = true
```

## Goals
This fix ensures that the tenant domain is correctly resolved from the service provider, and a proper tenant flow is initiated when the signature is added to the LogoutRequest. Fixes https://github.com/wso2/product-is/issues/24914.

## User stories
As a tenant user configuring front-channel SLO with POST binding in a federated authentication flow, I want the LogoutRequest to use the correct tenant certificate so that logout requests are properly validated and aligned with tenant-specific configurations.

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

## Release note
Fixed an issue where the super tenant’s certificate was incorrectly included in the LogoutRequest during front-channel SLO with POST binding in a federated flow. The correct tenant certificate is now used by properly resolving the tenant domain and initiating a tenant flow.

## Documentation
N/A. This change affects the underlying source code and does not correspond to a specific behavior configurable from the user's perspective.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes 
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 11, Mac OS Sonoma 14.4, H2 database, JDBC userstore
 