### PR TITLE
Add support for SESSION_EXPIRE event in SAMLLogoutHandler

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLLogoutHandler.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/SAMLLogoutHandler.java
@@ -56,7 +56,8 @@ public class SAMLLogoutHandler extends AbstractEventHandler {
         String samlssoTokenId = null;
         String issuer = null;
 
-        if (StringUtils.equals(event.getEventName(), EventName.SESSION_TERMINATE.name())) {
+        if (StringUtils.equals(event.getEventName(), EventName.SESSION_TERMINATE.name()) ||
+                StringUtils.equals(event.getEventName(), EventName.SESSION_EXPIRE.name())) {
             samlssoTokenId = getSamlSSOTokenIdFromEvent(event);
             String loggedInTenantDomain = getLoggedInTenantDomainFromEvent(event);
             if (StringUtils.isNotBlank(samlssoTokenId)) {


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/25396

## Related PRs

## Implementation
This pull request updates the event handling logic in the `SAMLLogoutHandler` to ensure that SAML SSO logout actions are triggered not only for session termination events but also for session expiration events. This change improves the robustness of the logout process by covering more scenarios where a user's session might end.

Event handling improvement:

* Updated the condition in the `handleEvent` method of `SAMLLogoutHandler.java` to handle both `SESSION_TERMINATE` and `SESSION_EXPIRE` events, ensuring SAML SSO logout is processed for session expiration as well as termination.

## Behaviour

https://github.com/user-attachments/assets/964dde69-854b-47f7-b9fe-a1c8c8bd063d


