### PR TITLE
Return SAML error response to SP ACS on user-cancelled authentication

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java
@@ -1240,10 +1240,20 @@ public class SAMLSSOProviderServlet extends HttpServlet {
                     statusCodes.add(SAMLSSOConstants.StatusCodes.AUTHN_FAILURE);
                     statusCodes.add(SAMLSSOConstants.StatusCodes.IDENTITY_PROVIDER_ERROR);
 
-                    String errorResp = SAMLSSOUtil.buildCompressedErrorResponse(authenticationRequestId, statusCodes,
-                            "User authentication failed", assertionConsumerURL);
-                    sendNotification(errorResp, SAMLSSOConstants.Notification.EXCEPTION_STATUS, SAMLSSOConstants
-                            .Notification.EXCEPTION_MESSAGE, assertionConsumerURL, req, resp);
+                    if (StringUtils.isNotBlank(assertionConsumerURL)) {
+                        // Build a POST-binding SAML error response and auto-submit it back to the SP's ACS
+                        // so the user returns to the application instead of landing on a dead-end page.
+                        String errorResp = SAMLSSOUtil.buildErrorResponse(authenticationRequestId, statusCodes,
+                                "User authentication failed", assertionConsumerURL);
+                        sendResponse(req, resp, sessionDTO.getRelayState(), errorResp, assertionConsumerURL,
+                                sessionDTO.getValidationRespDTO().getSubject(), null,
+                                sessionDTO.getTenantDomain());
+                    } else {
+                        String errorResp = SAMLSSOUtil.buildCompressedErrorResponse(authenticationRequestId,
+                                statusCodes, "User authentication failed", assertionConsumerURL);
+                        sendNotification(errorResp, SAMLSSOConstants.Notification.EXCEPTION_STATUS,
+                                SAMLSSOConstants.Notification.EXCEPTION_MESSAGE, assertionConsumerURL, req, resp);
+                    }
                     return;
                 } else {
                     throw IdentityException.error(IdentityException.class, "Could not find " + "session state " +

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServletAuthFailureTest.java
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServletAuthFailureTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.wso2.carbon.identity.sso.saml.servlet;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationResultCacheEntry;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationResult;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.model.SAMLSSOServiceProviderDO;
+import org.wso2.carbon.identity.sso.saml.SAMLSSOConstants;
+import org.wso2.carbon.identity.sso.saml.SSOServiceProviderConfigManager;
+import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOReqValidationResponseDTO;
+import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOSessionDTO;
+import org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtil;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Properties;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Tests for the authentication-failure branch in
+ * {@link SAMLSSOProviderServlet#handleAuthenticationReponseFromFramework}.
+ *
+ * Regression coverage for https://github.com/wso2/product-is/issues/27601:
+ * when the framework returns a non-authenticated AuthenticationResult during a
+ * SAML SSO flow (e.g. user cancels FIDO2 step), the IdP must build a
+ * POST-binding SAML error response and auto-submit it to the SP's ACS rather
+ * than forwarding to the dead-end samlsso_notification.jsp page.
+ */
+public class SAMLSSOProviderServletAuthFailureTest {
+
+    private static final String SENTINEL_BUILD_ERROR_RESPONSE = "SENTINEL_BUILD_ERROR_RESPONSE";
+    private static final String SENTINEL_BUILD_COMPRESSED_ERROR_RESPONSE = "SENTINEL_BUILD_COMPRESSED_ERROR_RESPONSE";
+    private static final String ACS_URL = "https://sp.example.org/acs";
+    private static final String REQUEST_ID = "saml-req-001";
+    private static final String ISSUER = "saml-fido-test";
+    private static final String RELAY_STATE = "relay-state-001";
+    private static final String SUBJECT = "admin";
+
+    @Test
+    public void testAuthFailureWithAcsUrl_buildsErrorResponseAndAutoPostsToAcs() throws Exception {
+
+        try (MockedStatic<SAMLSSOUtil> samlssoUtil = Mockito.mockStatic(SAMLSSOUtil.class);
+             MockedStatic<LoggerUtils> loggerUtils = Mockito.mockStatic(LoggerUtils.class);
+             MockedStatic<FrameworkUtils> frameworkUtils = Mockito.mockStatic(FrameworkUtils.class);
+             MockedStatic<SSOServiceProviderConfigManager> ssoCfgMgr =
+                     Mockito.mockStatic(SSOServiceProviderConfigManager.class)) {
+
+            SAMLSSOSessionDTO sessionDTO = prepareSessionDTO(ACS_URL, false);
+            HttpServletRequest request = prepareRequestWithFailedAuthResult();
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            setupCommonStaticStubs(samlssoUtil, loggerUtils, frameworkUtils, ssoCfgMgr, ACS_URL);
+
+            // The decision we want to verify: buildErrorResponse (auto-post to SP) must be
+            // invoked, NOT buildCompressedErrorResponse (render notification JSP).
+            // Throw a sentinel from buildErrorResponse so the downstream sendResponse path
+            // (which depends on collaborators we don't need to exercise here) is short-circuited.
+            samlssoUtil.when(() -> SAMLSSOUtil.buildErrorResponse(
+                    nullable(String.class), anyList(), nullable(String.class), nullable(String.class)))
+                    .thenThrow(new RuntimeException(SENTINEL_BUILD_ERROR_RESPONSE));
+            samlssoUtil.when(() -> SAMLSSOUtil.buildCompressedErrorResponse(
+                    nullable(String.class), anyList(), nullable(String.class), nullable(String.class)))
+                    .thenThrow(new RuntimeException(SENTINEL_BUILD_COMPRESSED_ERROR_RESPONSE));
+
+            SAMLSSOProviderServlet servlet = new SAMLSSOProviderServlet();
+            InvocationTargetException thrown = null;
+            try {
+                invokeHandleAuthenticationReponseFromFramework(servlet, request, response, sessionDTO);
+                fail("Expected one of the SAMLSSOUtil error-response builders to be invoked.");
+            } catch (InvocationTargetException e) {
+                thrown = e;
+            }
+
+            assertNotNull(thrown, "Expected InvocationTargetException from sentinel throw.");
+            Throwable cause = thrown.getCause();
+            assertNotNull(cause, "Sentinel cause must be present.");
+            assertEquals(cause.getMessage(), SENTINEL_BUILD_ERROR_RESPONSE,
+                    "When ACS URL is present, the fix must take the buildErrorResponse branch (auto-POST to ACS) "
+                            + "instead of the legacy buildCompressedErrorResponse/sendNotification branch.");
+
+            ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<List<String>> codesCaptor = ArgumentCaptor.forClass(List.class);
+            ArgumentCaptor<String> acsCaptor = ArgumentCaptor.forClass(String.class);
+            samlssoUtil.verify(() -> SAMLSSOUtil.buildErrorResponse(
+                    idCaptor.capture(), codesCaptor.capture(), anyString(), acsCaptor.capture()), times(1));
+            assertEquals(idCaptor.getValue(), REQUEST_ID);
+            assertEquals(acsCaptor.getValue(), ACS_URL);
+            List<String> codes = codesCaptor.getValue();
+            assertTrue(codes.contains(SAMLSSOConstants.StatusCodes.AUTHN_FAILURE),
+                    "Status codes must contain AUTHN_FAILURE.");
+            assertTrue(codes.contains(SAMLSSOConstants.StatusCodes.IDENTITY_PROVIDER_ERROR),
+                    "Status codes must contain IDENTITY_PROVIDER_ERROR as the top-level status.");
+
+            samlssoUtil.verify(() -> SAMLSSOUtil.buildCompressedErrorResponse(
+                    nullable(String.class), anyList(), nullable(String.class), nullable(String.class)), times(0));
+        }
+    }
+
+    @Test
+    public void testAuthFailureWithoutAcsUrl_fallsBackToNotificationPath() throws Exception {
+
+        try (MockedStatic<SAMLSSOUtil> samlssoUtil = Mockito.mockStatic(SAMLSSOUtil.class);
+             MockedStatic<LoggerUtils> loggerUtils = Mockito.mockStatic(LoggerUtils.class);
+             MockedStatic<FrameworkUtils> frameworkUtils = Mockito.mockStatic(FrameworkUtils.class);
+             MockedStatic<SSOServiceProviderConfigManager> ssoCfgMgr =
+                     Mockito.mockStatic(SSOServiceProviderConfigManager.class)) {
+
+            // Empty ACS URL on the session AND no default ACS in SP config → fallback branch
+            // (legacy buildCompressedErrorResponse/sendNotification path).
+            SAMLSSOSessionDTO sessionDTO = prepareSessionDTO(null, false);
+            HttpServletRequest request = prepareRequestWithFailedAuthResult();
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            setupCommonStaticStubs(samlssoUtil, loggerUtils, frameworkUtils, ssoCfgMgr, null);
+
+            samlssoUtil.when(() -> SAMLSSOUtil.buildErrorResponse(
+                    nullable(String.class), anyList(), nullable(String.class), nullable(String.class)))
+                    .thenThrow(new RuntimeException(SENTINEL_BUILD_ERROR_RESPONSE));
+            samlssoUtil.when(() -> SAMLSSOUtil.buildCompressedErrorResponse(
+                    nullable(String.class), anyList(), nullable(String.class), nullable(String.class)))
+                    .thenThrow(new RuntimeException(SENTINEL_BUILD_COMPRESSED_ERROR_RESPONSE));
+
+            SAMLSSOProviderServlet servlet = new SAMLSSOProviderServlet();
+            InvocationTargetException thrown = null;
+            try {
+                invokeHandleAuthenticationReponseFromFramework(servlet, request, response, sessionDTO);
+                fail("Expected one of the SAMLSSOUtil error-response builders to be invoked.");
+            } catch (InvocationTargetException e) {
+                thrown = e;
+            }
+
+            assertNotNull(thrown);
+            Throwable cause = thrown.getCause();
+            assertNotNull(cause);
+            assertEquals(cause.getMessage(), SENTINEL_BUILD_COMPRESSED_ERROR_RESPONSE,
+                    "When ACS URL is blank, the fallback buildCompressedErrorResponse branch must be taken "
+                            + "(preserving legacy behaviour).");
+
+            samlssoUtil.verify(() -> SAMLSSOUtil.buildErrorResponse(
+                    nullable(String.class), anyList(), nullable(String.class), nullable(String.class)), times(0));
+        }
+    }
+
+    @Test
+    public void testPassiveAuthFailure_stillUsesBuildErrorResponse() throws Exception {
+
+        // Passive-mode authentication failure has its own pre-existing branch that already calls
+        // buildErrorResponse + sendResponse. This test guards against accidentally regressing it
+        // while modifying the neighbouring user-cancel branch.
+        try (MockedStatic<SAMLSSOUtil> samlssoUtil = Mockito.mockStatic(SAMLSSOUtil.class);
+             MockedStatic<LoggerUtils> loggerUtils = Mockito.mockStatic(LoggerUtils.class);
+             MockedStatic<FrameworkUtils> frameworkUtils = Mockito.mockStatic(FrameworkUtils.class);
+             MockedStatic<SSOServiceProviderConfigManager> ssoCfgMgr =
+                     Mockito.mockStatic(SSOServiceProviderConfigManager.class)) {
+
+            SAMLSSOSessionDTO sessionDTO = prepareSessionDTO(ACS_URL, true);
+            HttpServletRequest request = prepareRequestWithFailedAuthResult();
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            setupCommonStaticStubs(samlssoUtil, loggerUtils, frameworkUtils, ssoCfgMgr, ACS_URL);
+
+            samlssoUtil.when(() -> SAMLSSOUtil.buildErrorResponse(
+                    nullable(String.class), anyList(), nullable(String.class), nullable(String.class)))
+                    .thenThrow(new RuntimeException(SENTINEL_BUILD_ERROR_RESPONSE));
+            samlssoUtil.when(() -> SAMLSSOUtil.buildCompressedErrorResponse(
+                    nullable(String.class), anyList(), nullable(String.class), nullable(String.class)))
+                    .thenThrow(new RuntimeException(SENTINEL_BUILD_COMPRESSED_ERROR_RESPONSE));
+
+            SAMLSSOProviderServlet servlet = new SAMLSSOProviderServlet();
+            InvocationTargetException thrown = null;
+            try {
+                invokeHandleAuthenticationReponseFromFramework(servlet, request, response, sessionDTO);
+                fail("Expected buildErrorResponse sentinel for passive-auth failure.");
+            } catch (InvocationTargetException e) {
+                thrown = e;
+            }
+
+            assertNotNull(thrown);
+            assertEquals(thrown.getCause().getMessage(), SENTINEL_BUILD_ERROR_RESPONSE);
+
+            ArgumentCaptor<List<String>> codesCaptor = ArgumentCaptor.forClass(List.class);
+            samlssoUtil.verify(() -> SAMLSSOUtil.buildErrorResponse(
+                    anyString(), codesCaptor.capture(), anyString(), anyString()), times(1));
+            assertTrue(codesCaptor.getValue().contains(SAMLSSOConstants.StatusCodes.NO_PASSIVE),
+                    "Passive-mode failure must carry NoPassive status code (unchanged by the fix).");
+        }
+    }
+
+    private void setupCommonStaticStubs(MockedStatic<SAMLSSOUtil> samlssoUtil,
+                                        MockedStatic<LoggerUtils> loggerUtils,
+                                        MockedStatic<FrameworkUtils> frameworkUtils,
+                                        MockedStatic<SSOServiceProviderConfigManager> ssoCfgMgr,
+                                        String defaultAcsUrl) {
+
+        loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+
+        samlssoUtil.when(() -> SAMLSSOUtil.splitAppendedTenantDomain(anyString()))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        frameworkUtils.when(() -> FrameworkUtils.getAuthenticationResultFromCache(anyString()))
+                .thenReturn((AuthenticationResultCacheEntry) null);
+
+        // Return a non-null SaaS SP config so getServiceProviderConfig skips the
+        // PrivilegedCarbonContext tenant-flow branch (that class is not instrumentable
+        // under the inline mock-maker in this JVM).
+        SAMLSSOServiceProviderDO spDO = mock(SAMLSSOServiceProviderDO.class);
+        when(spDO.getDefaultAssertionConsumerUrl()).thenReturn(defaultAcsUrl);
+        when(spDO.getCertAlias()).thenReturn(null);
+        when(spDO.isDoValidateSignatureInRequests()).thenReturn(false);
+
+        SSOServiceProviderConfigManager cfgMgr = mock(SSOServiceProviderConfigManager.class);
+        when(cfgMgr.getServiceProvider(anyString())).thenReturn(spDO);
+        ssoCfgMgr.when(SSOServiceProviderConfigManager::getInstance).thenReturn(cfgMgr);
+    }
+
+    private SAMLSSOSessionDTO prepareSessionDTO(String acsUrl, boolean passive) {
+
+        SAMLSSOReqValidationResponseDTO validationDTO = mock(SAMLSSOReqValidationResponseDTO.class);
+        when(validationDTO.isPassive()).thenReturn(passive);
+        when(validationDTO.getSubject()).thenReturn(SUBJECT);
+
+        SAMLSSOSessionDTO sessionDTO = mock(SAMLSSOSessionDTO.class);
+        when(sessionDTO.getAssertionConsumerURL()).thenReturn(acsUrl);
+        when(sessionDTO.getValidationRespDTO()).thenReturn(validationDTO);
+        // Blank tenant domain → code takes the super-tenant short-circuit (no realm service call).
+        when(sessionDTO.getTenantDomain()).thenReturn("");
+        when(sessionDTO.getRelayState()).thenReturn(RELAY_STATE);
+        when(sessionDTO.getIssuer()).thenReturn(ISSUER);
+        when(sessionDTO.getRequestID()).thenReturn(REQUEST_ID);
+        when(sessionDTO.getSubject()).thenReturn(SUBJECT);
+        when(sessionDTO.getProperties()).thenReturn(new Properties());
+        return sessionDTO;
+    }
+
+    private HttpServletRequest prepareRequestWithFailedAuthResult() {
+
+        AuthenticationResult authResult = mock(AuthenticationResult.class);
+        when(authResult.isAuthenticated()).thenReturn(false);
+        when(authResult.getProperty(FrameworkConstants.SESSION_AUTH_HISTORY)).thenReturn(null);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getAttribute(FrameworkConstants.RequestAttribute.AUTH_RESULT)).thenReturn(authResult);
+        return request;
+    }
+
+    private void invokeHandleAuthenticationReponseFromFramework(SAMLSSOProviderServlet servlet,
+                                                                HttpServletRequest req,
+                                                                HttpServletResponse resp,
+                                                                SAMLSSOSessionDTO sessionDTO)
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+        Method m = SAMLSSOProviderServlet.class.getDeclaredMethod(
+                "handleAuthenticationReponseFromFramework",
+                HttpServletRequest.class, HttpServletResponse.class, String.class, SAMLSSOSessionDTO.class);
+        m.setAccessible(true);
+        m.invoke(servlet, req, resp, "session-id-1", sessionDTO);
+    }
+}

--- a/components/org.wso2.carbon.identity.sso.saml/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.sso.saml/src/test/resources/testng.xml
@@ -22,6 +22,7 @@
         <classes>
             <class name="org.wso2.carbon.identity.sso.saml.servlet.SAMLSSOProviderServletTest" />
             <class name="org.wso2.carbon.identity.sso.saml.servlet.SAMLSSOProviderServletSendPostRequestTest" />
+            <class name="org.wso2.carbon.identity.sso.saml.servlet.SAMLSSOProviderServletAuthFailureTest" />
             <class name="org.wso2.carbon.identity.sso.saml.SAML2InboundAuthConfigHandlerTest"/>
             <class name="org.wso2.carbon.identity.sso.saml.util.AssertionBuildingTest" />
             <class name="org.wso2.carbon.identity.sso.saml.util.SAMLSSOUtilTest" />


### PR DESCRIPTION
## Issue
Fixes wso2/product-is#27601 — *FIDO2 flow cancellation with SAML2 authentication produces generic error*.

## Problem
When a user cancels the FIDO2 step (e.g. clicks **Cancel** on `fido2-passkey-status.jsp` because no passkey is registered) in a multi-step SAML SSO flow, the framework returns a not-authenticated `AuthenticationResult` to `SAMLSSOProviderServlet`. The servlet built a compressed error response and called `sendNotification(...)`, which forwarded to `authenticationendpoint/samlsso_notification.do`. This dead-end JSP renders:

> SAML 2.0 based Single Sign-On  
> Error when processing authentication request!  
> Please try login again!

No return link to the app, no link to My Account — the user is stranded at the IdP. The URL already carried a valid `SAMLResponse` and `ACSUrl` in the query string; it just wasn't being delivered to the SP. By contrast, `OAuth2AuthzEndpoint` redirects back to the client's `redirect_uri` with `error=access_denied`, so OIDC SPs silently receive the failure and can render their own UI — this is the parity the reporter asked for.

## Fix
In `SAMLSSOProviderServlet#handleAuthenticationReponseFromFramework`, when the framework returns `authResult != null && !authResult.isAuthenticated()` **and** the ACS URL is known, build a POST-binding SAML error response via `SAMLSSOUtil.buildErrorResponse(...)` and dispatch it through `sendResponse(...)` — the same auto-POST path used for successful assertions and passive-mode failures. The resulting `samlsso_response.jsp` contains a self-submitting form that POSTs the SAML error response to the SP's ACS, so the user is returned to the application with a standards-compliant `Responder` / `AuthnFailed` status.

When no ACS URL is available, the code falls back to the legacy `buildCompressedErrorResponse` + `sendNotification` path, preserving existing behaviour for that edge case. Other failure branches (invalid request, session-establishment failure after successful authn) are untouched.

The ACS URL was already validated during initial AuthnRequest validation, so no additional URL-validation hop is introduced.

## Changed files
| File | Change |
|------|--------|
| `components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServlet.java` | Auto-POST SAML error response to SP ACS on user-cancelled authentication; fall back to notification JSP only when ACS URL is absent. |
| `components/org.wso2.carbon.identity.sso.saml/src/test/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLSSOProviderServletAuthFailureTest.java` | New TestNG + Mockito test covering the three branches of the failure path. |
| `components/org.wso2.carbon.identity.sso.saml/src/test/resources/testng.xml` | Wire the new test class into the suite. |

## How verified
### Unit tests
Added `SAMLSSOProviderServletAuthFailureTest` (3 cases):
1. ACS URL present → must take the **new** `buildErrorResponse` + `sendResponse` branch. **Fails** against the pre-fix code (verified by stashing the servlet change), passes with the fix.
2. ACS URL absent → falls back to `buildCompressedErrorResponse` + `sendNotification` (existing behaviour preserved).
3. Passive-mode failure still carries `StatusCodes.NO_PASSIVE` and goes through `buildErrorResponse` (guards the neighbouring pre-existing branch from regressions).

Full module test run: 185/185 green.

```
mvn -pl components/org.wso2.carbon.identity.sso.saml -am test
```

### Runtime (Playwright against IS 7.3.0-rc1)
Patched the rebuilt `org.wso2.carbon.identity.sso.saml-5.12.5.jar` into IS and ran a Playwright driver:

1. Navigate to `https://localhost:9443/samlsso?spEntityID=saml-fido-test`.
2. Submit `admin`/`admin` → lands on `fido2-passkey-status.jsp` (admin has no passkey).
3. Click **Cancel**.

**Before the fix:** Browser lands on `authenticationendpoint/samlsso_notification.do?status=Error...&SAMLResponse=...&ACSUrl=...` (dead-end page).  
**After the fix:** Browser auto-POSTs to `https://localhost:9443/samlsso/acs` with a valid SAML 2.0 `<saml2p:Response>` — top-level `StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder"` and inner `AuthnFailed`. No request to `/samlsso_notification.do`. No `ERROR` / `Exception` entries in `wso2carbon.log`.

## Related
- wso2/product-is#27601